### PR TITLE
feat: save generated images to the session workspace

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -127,6 +127,7 @@ Click the **`[Gallery]`** Tab in the top navigation bar to browse and search all
 - 🎨 **Multi-Provider Support**: Supports Google Gemini, OpenAI Images, OpenAI Compatible API, and ByteDance Seedream / Volcengine Ark.
 - 🔑 **BYOK (Bring Your Own Key)**: Uses your own API keys managed securely by DSH credentials service with write-only protection.
 - 🖼️ **Durable Session Persistence**: Images integrate with DSH Attachment and conversation lifecycle, preserved across reloads.
+- 💾 **Workspace File Output**: By default each generated image is also written as a file into the current session workspace (`dsh-image-gen/` subfolder); the tool result carries the absolute file path. Can be disabled or re-pointed in settings.
 - ⚙️ **Native Web Settings**: Configure providers, keys, models, and endpoints directly in DSH settings.
 
 ---

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 - 🎨 **多 Provider 支持**：目前支持 Google Gemini、OpenAI Images、OpenAI Compatible API 以及 ByteDance Seedream / Volcengine Ark。Provider、模型和 Endpoint 都可以在设置界面中自由修改。
 - 🔑 **BYOK (自带 Key)**：插件使用你自己的 API Key。API Key 通过 DeepSeek Harness 的 `credentials` 服务管理，采用写保护隔离，不需要写进项目源码或配置文件，前端不存明文。
 - 🖼️ **图片跟随会话保存**：生成结果会接入 DeepSeek Harness 的 Attachment / Conversation 体系，重新打开历史会话后，仍然可以看到之前生成的图片。
+- 💾 **生成图片自动落盘到工作区**：默认在每次生成后把图片文件保存到当前会话工作区（`dsh-image-gen/` 子目录），工具结果会返回文件的绝对路径；可在设置中关闭或修改保存目录。
 - ⚙️ **原生设置界面**：Provider、API Key、模型和 Endpoint 都可以直接在 DSH Web 设置中修改，不需要手动编辑配置文件。
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -127,6 +127,7 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 - 🎨 **多 Provider 支持**：目前支持 Google Gemini、OpenAI Images、OpenAI Compatible API 以及 ByteDance Seedream / Volcengine Ark。Provider、模型和 Endpoint 都可以在设置界面中自由修改。
 - 🔑 **BYOK (自带 Key)**：插件使用你自己的 API Key。API Key 通过 DeepSeek Harness 的 `credentials` 服务管理，采用写保护隔离，不需要写进项目源码或配置文件，前端不存明文。
 - 🖼️ **图片跟随会话保存**：生成结果会接入 DeepSeek Harness 的 Attachment / Conversation 体系，重新打开历史会话后，仍然可以看到之前生成的图片。
+- 💾 **生成图片自动落盘到工作区**：默认在每次生成后把图片文件保存到当前会话工作区（`dsh-image-gen/` 子目录），工具结果会返回文件的绝对路径；可在设置中关闭或修改保存目录。
 - ⚙️ **原生设置界面**：Provider、API Key、模型和 Endpoint 都可以直接在 DSH Web 设置中修改，不需要手动编辑配置文件。
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-image-gen",
-  "version": "0.2.0",
+  "version": "0.1.4",
   "description": "Bring ChatGPT-like image generation to DeepSeek Harness — Gemini, OpenAI, Seedream & more.",
   "type": "module",
   "author": "shanliuling",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-image-gen",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Bring ChatGPT-like image generation to DeepSeek Harness — Gemini, OpenAI, Seedream & more.",
   "type": "module",
   "author": "shanliuling",

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -20,7 +20,7 @@ import { saveGalleryItem } from './gallery-store.js'
 import { GalleryViewTab, copyImageBlob, type LocaleService } from './gallery-view.js'
 
 type Provider = ImageProvider
-interface ImageSettings { provider?: Provider; googleModel?: string; googleEndpoint?: string; openaiBaseURL?: string; openaiModel?: string; seedreamBaseURL?: string; seedreamModel?: string }
+interface ImageSettings { provider?: Provider; googleModel?: string; googleEndpoint?: string; openaiBaseURL?: string; openaiModel?: string; seedreamBaseURL?: string; seedreamModel?: string; saveToWorkspace?: boolean; workspaceFolder?: string }
 interface SettingsFace { scope: SettingsScope<ImageSettings>; credentials: ConnectionHandle['api']['credentials']; locale?: LocaleService | undefined }
 interface ImageCardFace { locale?: LocaleService | undefined }
 type SettingsCardProps = PropsRuntime<'settings.plugin.item'> & InjectFace<SettingsFace>
@@ -46,9 +46,14 @@ const DICT = {
     endpointHintOpenAI: '中转站请填其 OpenAI 兼容的 /v1 地址。',
     endpointHintSeedream: '火山方舟兼容的 /api/v3 地址。',
     model: '模型',
+    saveToWorkspace: '保存到工作区',
+    saveToWorkspaceHint: '每次生成后，把图片文件保存到当前会话工作区。',
+    folder: '工作区文件夹',
+    folderHint: '相对当前会话工作区的子目录；留空表示工作区根目录。',
     saving: '保存中…',
     save: '保存',
     saved: '已保存',
+    savedToPath: '已保存到',
     checkingKey: '正在检查 API Key…',
     keyConfigured: '已配置 API Key',
     keyNotConfigured: '尚未配置 API Key',
@@ -79,9 +84,14 @@ const DICT = {
     endpointHintOpenAI: 'OpenAI-compatible /v1 base URL for relays.',
     endpointHintSeedream: 'Volcengine Ark compatible /api/v3 base URL.',
     model: 'Model',
+    saveToWorkspace: 'Save to workspace',
+    saveToWorkspaceHint: 'Write each generated image as a file into the session workspace.',
+    folder: 'Workspace folder',
+    folderHint: 'Subdirectory of the session workspace; empty means the workspace root.',
     saving: 'Saving…',
     save: 'Save',
     saved: 'Saved',
+    savedToPath: 'Saved to',
     checkingKey: 'Checking API Key…',
     keyConfigured: 'API Key configured',
     keyNotConfigured: 'API Key not configured',
@@ -120,6 +130,9 @@ const STYLE = `
 .dsh-ig-btn-reset:hover{background:var(--dsw-alias-bg-layer-2,#edf0f3);border-color:var(--dsw-alias-label-dimmed,#9ca3af)}
 .dsh-ig-hint,.dsh-ig-status{margin:0;color:var(--dsw-alias-label-tertiary,#7b818b);font-size:12px;line-height:1.4}
 .dsh-ig-actions{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:16px;padding-top:12px;border-top:1px solid var(--dsw-alias-border-l2,#eee)}
+.dsh-ig-check-row{display:flex;align-items:center;gap:8px;cursor:pointer}
+.dsh-ig-check-row input[type=checkbox]{width:15px;height:15px;accent-color:var(--dsw-alias-brand-primary,#4c78ff);margin:0}
+.dsh-ig-savedto{font-size:12px;line-height:1.5;color:var(--dsw-alias-label-tertiary,#7b818b);word-break:break-all}
 .dsh-ig-save{appearance:none;border:0;border-radius:8px;padding:6px 16px;background:var(--dsw-alias-label-primary,#111827);color:var(--dsw-alias-bg-layer-3,#fff);font:inherit;font-size:13px;font-weight:500;cursor:pointer;transition:opacity .15s}
 .dsh-ig-save:disabled{opacity:.4;cursor:default}
 
@@ -248,6 +261,8 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
   const [provider, setProvider] = useState<Provider>('google')
   const [model, setModel] = useState('')
   const [baseURL, setBaseURL] = useState('')
+  const [saveToWorkspace, setSaveToWorkspace] = useState(true)
+  const [workspaceFolder, setWorkspaceFolder] = useState('dsh-image-gen')
   const [key, setKey] = useState('')
   const [configured, setConfigured] = useState<boolean | undefined>()
   const [saving, setSaving] = useState(false)
@@ -281,6 +296,8 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
     const value = snapshot.value
     const next = value?.provider ?? 'google'
     setProvider(next); setModel(modelOf(next, value)); setBaseURL(baseURLOf(next, value))
+    setSaveToWorkspace(value?.saveToWorkspace ?? true)
+    setWorkspaceFolder(value?.workspaceFolder ?? 'dsh-image-gen')
   }, [snapshot])
 
   useEffect(() => {
@@ -297,6 +314,8 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
       await props.scope.set('provider', provider)
       await props.scope.set(provider === 'google' ? 'googleModel' : provider === 'openai' ? 'openaiModel' : 'seedreamModel', model)
       await props.scope.set(provider === 'google' ? 'googleEndpoint' : provider === 'openai' ? 'openaiBaseURL' : 'seedreamBaseURL', baseURL)
+      await props.scope.set('saveToWorkspace', saveToWorkspace)
+      await props.scope.set('workspaceFolder', workspaceFolder.trim())
       if (key.trim().length > 0) {
         const response = await props.credentials.set({ ref: KEY_REF[provider], value: key.trim() })
         if (!response.result.ok) throw new Error(response.result.error.message)
@@ -347,6 +366,20 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
             <span className="dsh-ig-label">{t('model')}</span>
             <input className="dsh-ig-input" value={model} onChange={event => { setModel(event.target.value) }} required />
           </label>
+          <div className="dsh-ig-field">
+            <label className="dsh-ig-check-row">
+              <input type="checkbox" checked={saveToWorkspace} onChange={event => { setSaveToWorkspace(event.target.checked) }} />
+              <span className="dsh-ig-label">{t('saveToWorkspace')}</span>
+            </label>
+            <span className="dsh-ig-hint">{t('saveToWorkspaceHint')}</span>
+          </div>
+          {saveToWorkspace ? (
+            <label className="dsh-ig-field">
+              <span className="dsh-ig-label">{t('folder')}</span>
+              <input className="dsh-ig-input" value={workspaceFolder} onChange={event => { setWorkspaceFolder(event.target.value) }} placeholder="dsh-image-gen" />
+              <span className="dsh-ig-hint">{t('folderHint')}</span>
+            </label>
+          ) : null}
           <div className="dsh-ig-actions">
             <p className="dsh-ig-status" role="status">{message || keyStatus}</p>
             <button className="dsh-ig-save" type="submit" disabled={saving || !snapshot.writable}>{saving ? t('saving') : t('save')}</button>
@@ -360,6 +393,7 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
 /** Render the durable attachment referenced by a completed image tool call. */
 export function GeneratedImageCard(props: ImageCardProps) {
   const attachment = imageRef(props.block)
+  const savedTo = imageSavedTo(props.block)
   const [url, setUrl] = useState<string>()
   const [blob, setBlob] = useState<Blob>()
   const [error, setError] = useState<string>()
@@ -470,6 +504,7 @@ export function GeneratedImageCard(props: ImageCardProps) {
   if (attachment === undefined) return <div className="dsh-ig-loading">{t('generating')}</div>
   return <section className="dsh-ig-result" aria-label={t('generatedTitle')}>
     <div className="dsh-ig-result-title">{t('generatedTitle')}</div>
+    {savedTo !== undefined ? <div className="dsh-ig-savedto">{t('savedToPath')}: {savedTo}</div> : null}
     {error !== undefined ? <div className="dsh-ig-error">{error}</div> : null}
     {url === undefined && error === undefined ? <div className="dsh-ig-loading">{t('loading')}</div> : null}
     {url !== undefined ? <div className="dsh-ig-container">
@@ -516,3 +551,11 @@ function baseURLOf(provider: Provider, value: ImageSettings | undefined): string
 }
 
 function imageRef(block: ToolCallBlock): ImageAttachmentRef | undefined { if (!('kind' in block) || block.resultView?.card !== 'generic') return undefined; const image = block.resultView.content?.find(item => item.type === 'image'); return image?.type === 'image' ? image.attachment : undefined }
+
+/** The workspace file path a completed image call saved, when the result meta carries one. */
+function imageSavedTo(block: ToolCallBlock): string | undefined {
+  if (!('kind' in block)) return undefined
+  const meta = (block as unknown as { meta?: { savedTo?: unknown } }).meta
+    ?? (block.resultView as unknown as { meta?: { savedTo?: unknown } } | undefined)?.meta
+  return typeof meta?.savedTo === 'string' ? meta.savedTo : undefined
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,9 @@ export {
   type ImageProvider,
 }
 
+/** Default workspace subfolder that receives generated image files. */
+export const DEFAULT_WORKSPACE_FOLDER = 'dsh-image-gen'
+
 /** Google API credential reference. */
 export const GOOGLE_API_KEY_ENV = 'GEMINI_API_KEY'
 /** OpenAI Platform or compatible relay credential reference. */
@@ -45,6 +48,10 @@ export interface Config {
   openaiModel?: string
   seedreamBaseURL?: string
   seedreamModel?: string
+  /** Also write every generated image as a file under the session workspace. */
+  saveToWorkspace?: boolean
+  /** Workspace subfolder for generated images; empty means the workspace root. */
+  workspaceFolder?: string
 }
 
 /** Cordis configuration schema. */
@@ -56,6 +63,8 @@ export const Config: z<Config> = z.object({
   openaiModel: z.string().default(DEFAULT_OPENAI_MODEL),
   seedreamBaseURL: z.string().default(DEFAULT_SEEDREAM_BASE_URL),
   seedreamModel: z.string().default(DEFAULT_SEEDREAM_MODEL),
+  saveToWorkspace: z.boolean().default(true),
+  workspaceFolder: z.string().default(DEFAULT_WORKSPACE_FOLDER),
 })
 
 /** Resolve exactly one provider profile for a tool call. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,9 @@ async function saveGenerated(
       signal: exec.signal,
     })
   } catch (error) {
+    // A cancellation is never reported as a (partial) success: rethrow it even
+    // if the workspace write had already finished when the signal fired.
+    exec.signal.throwIfAborted()
     ctx.logger.warn(`dsh-image-gen: failed to save image to workspace: ${error instanceof Error ? error.message : String(error)}`)
     value.saveError = error instanceof Error ? error.message : String(error)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { generateGoogleImage } from './google.js'
 import { IMAGE_ROUTE, imageAttachmentFromMeta, serveImage } from './image-route.js'
 import { generateOpenAICompatibleImage } from './openai-compatible.js'
 import { IMAGE_GENERATION_NAMESPACE } from './shared.js'
+import { saveImageToWorkspace } from './workspace-save.js'
 
 export { Config } from './config.js'
 export { IMAGE_ROUTE, imageAttachmentFromMeta } from './image-route.js'
@@ -24,6 +25,10 @@ interface GeneratedValue {
   provider: ImageProvider
   model: string
   output: string
+  /** Absolute path of the workspace file copy, when the image was saved to the session workspace. */
+  savedTo?: string
+  /** Why the workspace file copy could not be written, when generation still succeeded. */
+  saveError?: string
 }
 
 /** Register settings, the image route, and the model-callable tool. */
@@ -39,7 +44,7 @@ export function apply(ctx: Context, config: Config = {}): void {
 
   ctx.tools.register(defineTool({
     name: 'generate_image',
-    description: 'Generate one image with the configured image provider. Use when the user explicitly asks to create or draw an image. Give a complete visual prompt including subject, composition, style, lighting, and any exact text that should appear. A successful image is already attached directly to the conversation and has no local file path; do not call read, glob, or other tools to locate or verify it.',
+    description: 'Generate one image with the configured image provider. Use when the user explicitly asks to create or draw an image. Give a complete visual prompt including subject, composition, style, lighting, and any exact text that should appear. A successful image is already attached directly to the conversation; with workspace saving enabled (the default) it is also written as a file under the session workspace, and the result\'s savedTo field carries that absolute file path. Do not call read, glob, or other tools to locate or verify the image.',
     parameters: {
       prompt: { type: 'string', required: true, description: 'Complete description of the image to generate.' },
       aspect_ratio: { type: 'string', enum: ['1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16'], description: 'Optional output aspect ratio for Google Gemini.' },
@@ -53,15 +58,20 @@ export function apply(ctx: Context, config: Config = {}): void {
             attachmentId: { type: 'string', required: true }, mediaType: { type: 'string', required: true }, bytes: { type: 'integer', required: true }, width: { type: 'integer', required: true }, height: { type: 'integer', required: true }, name: { type: 'string' },
           } },
           provider: { type: 'string', required: true }, model: { type: 'string', required: true }, output: { type: 'string', required: true },
+          savedTo: { type: 'string' }, saveError: { type: 'string' },
         },
       },
-      render: (_args, value) => [{ type: 'text', text: `Generated one image with ${value.provider}/${value.model} (${value.output}). It is already attached to the conversation with no local file path; respond to the user without reading or searching for it.` }],
+      render: (_args, value) => {
+        const saved = typeof value.savedTo === 'string' ? ` It was also saved to the workspace as ${value.savedTo}.` : typeof value.saveError === 'string' ? ` Saving it to the workspace failed: ${value.saveError}.` : ' It has no local file path.'
+        return [{ type: 'text', text: `Generated one image with ${value.provider}/${value.model} (${value.output}). It is already attached to the conversation.${saved} Respond to the user without reading or searching for the image.` }]
+      },
       presentationMeta: (args, value) => ({
         kind: 'dsh-image-gen',
         attachment: value.attachment,
         provider: value.provider,
         model: value.model,
         output: value.output,
+        ...(typeof value.savedTo === 'string' ? { savedTo: value.savedTo } : {}),
         prompt: (args as { prompt: string }).prompt,
       }),
     },
@@ -73,20 +83,51 @@ export function apply(ctx: Context, config: Config = {}): void {
         const aspectRatio = (args.aspect_ratio ?? active.aspectRatio) as AspectRatio
         const imageSize = (args.image_size ?? active.imageSize) as ImageSize
         const generated = await generateGoogleImage({ apiKey: credential.value, endpoint: active.endpoint, model: active.model, prompt: args.prompt, aspectRatio, imageSize, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
-        return saveGenerated(ctx, generated, active.provider, active.model, `${aspectRatio}, ${imageSize}`)
+        return saveGenerated(ctx, generated, active.provider, active.model, `${aspectRatio}, ${imageSize}`, current(), exec)
       }
       const size = args.size ?? active.imageSize
       const generated = await generateOpenAICompatibleImage({ provider: active.provider, apiKey: credential.value, baseURL: active.baseURL, model: active.model, prompt: args.prompt, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
-      return saveGenerated(ctx, generated, active.provider, active.model, size)
+      return saveGenerated(ctx, generated, active.provider, active.model, size, current(), exec)
     },
     presentResult: (_args, result) => imagePresentation(result),
   }))
 }
 
-async function saveGenerated(ctx: Context, generated: { data: Uint8Array; mediaType: ImageAttachmentRef['mediaType'] }, provider: ImageProvider, model: string, output: string): Promise<GeneratedValue> {
+/**
+ * Persist the generated image as a durable attachment, then — when workspace
+ * saving is enabled — also write it as a file under the calling agent's
+ * session workspace. A workspace write failure never discards the generated
+ * attachment: it is reported through `saveError` instead.
+ */
+async function saveGenerated(
+  ctx: Context,
+  generated: { data: Uint8Array; mediaType: ImageAttachmentRef['mediaType'] },
+  provider: ImageProvider,
+  model: string,
+  output: string,
+  config: Config,
+  exec: { agent?: { session: { header: { cwd?: string } } }; signal: AbortSignal },
+): Promise<GeneratedValue> {
   if (!ctx.attachments.imageLimits.mediaTypes.includes(generated.mediaType)) throw new Error(`This DSH deployment does not accept ${generated.mediaType} generated images`)
   const attachment = await ctx.attachments.saveImage({ data: generated.data, mediaType: generated.mediaType, name: 'generated-image' })
-  return { attachment, provider, model, output }
+  const value: GeneratedValue = { attachment, provider, model, output }
+  if (config.saveToWorkspace === false) return value
+  const workspaceRoot = exec.agent?.session.header.cwd
+  if (workspaceRoot === undefined) return value
+  try {
+    value.savedTo = await saveImageToWorkspace({
+      workspaceRoot,
+      folder: config.workspaceFolder,
+      attachmentId: attachment.attachmentId,
+      mediaType: generated.mediaType,
+      data: generated.data,
+      signal: exec.signal,
+    })
+  } catch (error) {
+    ctx.logger.warn(`dsh-image-gen: failed to save image to workspace: ${error instanceof Error ? error.message : String(error)}`)
+    value.saveError = error instanceof Error ? error.message : String(error)
+  }
+  return value
 }
 
 function imagePresentation(result: ToolResult) {

--- a/src/workspace-save.ts
+++ b/src/workspace-save.ts
@@ -1,7 +1,7 @@
 /** Persist one generated image as a file under the session workspace. */
 import { randomUUID } from 'node:crypto'
-import { mkdir, rename, unlink, writeFile } from 'node:fs/promises'
-import { join, resolve, sep } from 'node:path'
+import { mkdir, realpath, rename, unlink, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { ImageAttachmentRef } from '@deepseek-ai/dsh-attachment'
 
 /** File extension for each supported image media type. */
@@ -13,32 +13,32 @@ const EXTENSION: Record<ImageAttachmentRef['mediaType'], string> = {
 }
 
 /**
- * Build one human-readable, collision-resistant file name for a generated
- * image: `image-YYYYMMDD-HHMMSS-<digest-prefix>.<ext>` using UTC. The digest
- * prefix is the content-addressed attachment id, so the same image bytes
- * always map to the same file name.
+ * Build the deterministic file name for a generated image:
+ * `image-<digest-prefix>.<ext>`. The digest prefix comes from the
+ * content-addressed attachment id, so the same image bytes always map to the
+ * same file name regardless of when they were generated, and re-saving simply
+ * overwrites the previous copy in place.
  * @param attachmentId - durable attachment id (`sha256:<hex>`).
  * @param mediaType - verified image media type.
- * @param now - clock for the stamp; injectable for tests.
  * @returns the file name (no directory).
  */
 export function workspaceImageName(
   attachmentId: string,
   mediaType: ImageAttachmentRef['mediaType'],
-  now: Date = new Date(),
 ): string {
   const digest = attachmentId.startsWith('sha256:') ? attachmentId.slice('sha256:'.length) : attachmentId
   const prefix = digest.slice(0, 8).padEnd(8, '0')
-  const pad = (value: number) => String(value).padStart(2, '0')
-  const stamp = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}`
-    + `-${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}`
-  return `image-${stamp}-${prefix}.${EXTENSION[mediaType]}`
+  return `image-${prefix}.${EXTENSION[mediaType]}`
 }
 
 /**
  * Resolve the configured image folder inside the session workspace. The
  * folder may nest, but must stay inside the workspace: absolute paths and
  * parent-traversal segments are rejected for both separator styles.
+ *
+ * This lexical pass is necessary but not sufficient: `saveImageToWorkspace`
+ * additionally verifies the on-disk resolution so symlinked folders cannot
+ * escape the workspace.
  * @param workspaceRoot - the session workspace directory.
  * @param folder - configured subfolder; empty/blank means the workspace root.
  * @returns the absolute image directory.
@@ -49,19 +49,58 @@ export function workspaceImageDir(workspaceRoot: string, folder: string | undefi
   const root = resolve(workspaceRoot)
   // An absolute folder resolves to itself and is rejected by the containment check below.
   const dir = trimmed === '' ? root : resolve(root, trimmed)
-  if (dir !== root && !dir.startsWith(root + sep)) {
+  if (!containsPath(root, dir)) {
     throw new Error(`image workspace folder '${folder}' must stay inside the session workspace`)
   }
   return dir
 }
 
+/** True when `child` equals `parent` or lives underneath it (lexically). */
+function containsPath(parent: string, child: string): boolean {
+  const rel = relative(parent, child)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+/**
+ * Real path of the closest existing ancestor of `dir` (inclusive). Walking up
+ * lets us validate symlinked folder segments before creating anything under
+ * them.
+ */
+async function nearestExistingRealPath(dir: string): Promise<string> {
+  let probe = dir
+  for (;;) {
+    try {
+      return await realpath(probe)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error
+      const parent = dirname(probe)
+      if (parent === probe) throw error // reached the filesystem root
+      probe = parent
+    }
+  }
+}
+
+/** Reject a directory whose on-disk resolution lands outside the workspace. */
+function assertInsideWorkspace(realRoot: string, candidate: string, folder: string | undefined): void {
+  if (containsPath(realRoot, candidate)) return
+  throw new Error(`image workspace folder '${folder ?? ''}' must stay inside the session workspace (${candidate} resolves outside ${realRoot})`)
+}
+
 /**
  * Write one generated image durably under the session workspace.
+ *
+ * Containment is enforced twice: lexically by `workspaceImageDir`, then
+ * against real paths, so a configured folder (or any intermediate segment)
+ * that is a symlink pointing outside the workspace is rejected before and
+ * after anything is created.
  *
  * The bytes are written to a same-directory staging file and renamed onto the
  * target, so a crash never leaves a half-written image under its final name.
  * Re-saving identical bytes rewrites the same file (the name is content-
- * addressed), which keeps repeated generations idempotent.
+ * addressed), which keeps repeated generations idempotent. A cancellation is
+ * honoured up to and including the final rename: an aborted save never
+ * resolves successfully and never leaves the image behind under its final
+ * name.
  * @param options - workspace root, configured folder, attachment identity, and image bytes.
  * @returns the absolute path of the written file.
  */
@@ -74,17 +113,31 @@ export async function saveImageToWorkspace(options: {
   signal?: AbortSignal
 }): Promise<string> {
   const dir = workspaceImageDir(options.workspaceRoot, options.folder)
+  options.signal?.throwIfAborted()
+  const realRoot = await realpath(resolve(options.workspaceRoot))
+  assertInsideWorkspace(realRoot, await nearestExistingRealPath(dir), options.folder)
   const name = workspaceImageName(options.attachmentId, options.mediaType)
   const target = join(dir, name)
   const staging = join(dir, `.${name}.${process.pid}-${randomUUID()}.tmp`)
   await mkdir(dir, { recursive: true })
-  options.signal?.throwIfAborted()
+  // Re-validate the finished directory: creating it may have traversed a
+  // symlink, and links can be swapped in between the checks above.
+  assertInsideWorkspace(realRoot, await realpath(dir), options.folder)
   try {
-    await writeFile(staging, options.data, { flag: 'wx' })
+    await writeFile(staging, options.data, { flag: 'wx', signal: options.signal })
     options.signal?.throwIfAborted()
     await rename(staging, target)
   } catch (error) {
     await unlink(staging).catch(() => {})
+    throw error
+  }
+  // Final gate: a cancellation landing during the last write/rename step must
+  // not be reported as a successful save, and the already-renamed file is
+  // removed so no orphan image outlives the cancelled call.
+  try {
+    options.signal?.throwIfAborted()
+  } catch (error) {
+    await unlink(target).catch(() => {})
     throw error
   }
   return target

--- a/src/workspace-save.ts
+++ b/src/workspace-save.ts
@@ -1,0 +1,91 @@
+/** Persist one generated image as a file under the session workspace. */
+import { randomUUID } from 'node:crypto'
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
+import type { ImageAttachmentRef } from '@deepseek-ai/dsh-attachment'
+
+/** File extension for each supported image media type. */
+const EXTENSION: Record<ImageAttachmentRef['mediaType'], string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+}
+
+/**
+ * Build one human-readable, collision-resistant file name for a generated
+ * image: `image-YYYYMMDD-HHMMSS-<digest-prefix>.<ext>` using UTC. The digest
+ * prefix is the content-addressed attachment id, so the same image bytes
+ * always map to the same file name.
+ * @param attachmentId - durable attachment id (`sha256:<hex>`).
+ * @param mediaType - verified image media type.
+ * @param now - clock for the stamp; injectable for tests.
+ * @returns the file name (no directory).
+ */
+export function workspaceImageName(
+  attachmentId: string,
+  mediaType: ImageAttachmentRef['mediaType'],
+  now: Date = new Date(),
+): string {
+  const digest = attachmentId.startsWith('sha256:') ? attachmentId.slice('sha256:'.length) : attachmentId
+  const prefix = digest.slice(0, 8).padEnd(8, '0')
+  const pad = (value: number) => String(value).padStart(2, '0')
+  const stamp = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}`
+    + `-${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}`
+  return `image-${stamp}-${prefix}.${EXTENSION[mediaType]}`
+}
+
+/**
+ * Resolve the configured image folder inside the session workspace. The
+ * folder may nest, but must stay inside the workspace: absolute paths and
+ * parent-traversal segments are rejected for both separator styles.
+ * @param workspaceRoot - the session workspace directory.
+ * @param folder - configured subfolder; empty/blank means the workspace root.
+ * @returns the absolute image directory.
+ * @throws when the folder would escape the workspace root.
+ */
+export function workspaceImageDir(workspaceRoot: string, folder: string | undefined): string {
+  const trimmed = (folder ?? '').trim()
+  const root = resolve(workspaceRoot)
+  // An absolute folder resolves to itself and is rejected by the containment check below.
+  const dir = trimmed === '' ? root : resolve(root, trimmed)
+  if (dir !== root && !dir.startsWith(root + sep)) {
+    throw new Error(`image workspace folder '${folder}' must stay inside the session workspace`)
+  }
+  return dir
+}
+
+/**
+ * Write one generated image durably under the session workspace.
+ *
+ * The bytes are written to a same-directory staging file and renamed onto the
+ * target, so a crash never leaves a half-written image under its final name.
+ * Re-saving identical bytes rewrites the same file (the name is content-
+ * addressed), which keeps repeated generations idempotent.
+ * @param options - workspace root, configured folder, attachment identity, and image bytes.
+ * @returns the absolute path of the written file.
+ */
+export async function saveImageToWorkspace(options: {
+  workspaceRoot: string
+  folder?: string | undefined
+  attachmentId: string
+  mediaType: ImageAttachmentRef['mediaType']
+  data: Uint8Array
+  signal?: AbortSignal
+}): Promise<string> {
+  const dir = workspaceImageDir(options.workspaceRoot, options.folder)
+  const name = workspaceImageName(options.attachmentId, options.mediaType)
+  const target = join(dir, name)
+  const staging = join(dir, `.${name}.${process.pid}-${randomUUID()}.tmp`)
+  await mkdir(dir, { recursive: true })
+  options.signal?.throwIfAborted()
+  try {
+    await writeFile(staging, options.data, { flag: 'wx' })
+    options.signal?.throwIfAborted()
+    await rename(staging, target)
+  } catch (error) {
+    await unlink(staging).catch(() => {})
+    throw error
+  }
+  return target
+}

--- a/tests/workspace-save.spec.ts
+++ b/tests/workspace-save.spec.ts
@@ -1,26 +1,39 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { saveImageToWorkspace, workspaceImageDir, workspaceImageName } from '../src/workspace-save.js'
 
-const FIXED_DATE = new Date(Date.UTC(2026, 0, 15, 8, 4, 9))
 const isWin = process.platform === 'win32'
 const root = isWin ? 'H:\\ws' : '/ws'
 const foreignAbs = isWin ? 'C:\\other' : '/etc'
 const parentTraversal = isWin ? '..\\escape' : '../escape'
 
+// Route every rename through a hook queue so tests can land an abort exactly
+// during the final rename step of a save.
+const renameHooks = vi.hoisted(() => ({ queue: [] as Array<() => void> }))
+vi.mock('node:fs/promises', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rename: async (...args: [oldPath: string, newPath: string]) => {
+      for (const hook of renameHooks.queue.splice(0)) hook()
+      return actual.rename(...args)
+    },
+  }
+})
+
 describe('workspaceImageName', () => {
-  it('builds a UTC-stamped, digest-suffixed name per media type', () => {
-    expect(workspaceImageName('sha256:0123456789abcdef', 'image/png', FIXED_DATE)).toBe('image-20260115-080409-01234567.png')
-    expect(workspaceImageName('sha256:0123456789abcdef', 'image/jpeg', FIXED_DATE)).toBe('image-20260115-080409-01234567.jpg')
-    expect(workspaceImageName('sha256:0123456789abcdef', 'image/webp', FIXED_DATE)).toBe('image-20260115-080409-01234567.webp')
-    expect(workspaceImageName('sha256:0123456789abcdef', 'image/gif', FIXED_DATE)).toBe('image-20260115-080409-01234567.gif')
+  it('derives a stable digest-suffixed name per media type', () => {
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/png')).toBe('image-01234567.png')
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/jpeg')).toBe('image-01234567.jpg')
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/webp')).toBe('image-01234567.webp')
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/gif')).toBe('image-01234567.gif')
   })
 
   it('accepts bare digests and pads short digests to eight chars', () => {
-    expect(workspaceImageName('abcdef', 'image/png', FIXED_DATE)).toBe('image-20260115-080409-abcdef00.png')
-    expect(workspaceImageName('abc', 'image/png', FIXED_DATE)).toBe('image-20260115-080409-abc00000.png')
+    expect(workspaceImageName('abcdef', 'image/png')).toBe('image-abcdef00.png')
+    expect(workspaceImageName('abc', 'image/png')).toBe('image-abc00000.png')
   })
 })
 
@@ -72,12 +85,62 @@ describe('saveImageToWorkspace', () => {
     } finally { await rm(base, { recursive: true, force: true }) }
   })
 
-  it('honours an already-aborted signal without writing', async () => {
+  it('honours an already-aborted signal without touching the disk', async () => {
     const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
     try {
       const controller = new AbortController()
       controller.abort()
       await expect(saveImageToWorkspace({ workspaceRoot: base, folder: undefined, attachmentId: 'sha256:bbbb2222', mediaType: 'image/png', data: new Uint8Array([9]), signal: controller.signal })).rejects.toThrow()
+      expect(await readdir(base)).toEqual([])
+    } finally { await rm(base, { recursive: true, force: true }) }
+  })
+
+  it('rejects a configured folder that symlinks outside the workspace', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    const outside = await mkdtemp(join(tmpdir(), 'dsh-image-gen-out-'))
+    try {
+      await symlink(outside, join(base, 'escape'), isWin ? 'junction' : 'dir')
+      await expect(saveImageToWorkspace({ workspaceRoot: base, folder: 'escape', attachmentId: 'sha256:cccc3333', mediaType: 'image/png', data: new Uint8Array([7]) })).rejects.toThrow(/must stay inside/)
+      expect(await readdir(outside)).toEqual([])
+    } finally {
+      await rm(base, { recursive: true, force: true })
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an escaping symlink on an intermediate folder segment', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    const outside = await mkdtemp(join(tmpdir(), 'dsh-image-gen-out-'))
+    try {
+      await mkdir(join(base, 'sub'))
+      await symlink(outside, join(base, 'sub', 'escape'), isWin ? 'junction' : 'dir')
+      await expect(saveImageToWorkspace({ workspaceRoot: base, folder: 'sub/escape', attachmentId: 'sha256:dddd4444', mediaType: 'image/png', data: new Uint8Array([7]) })).rejects.toThrow(/must stay inside/)
+      expect(await readdir(outside)).toEqual([])
+    } finally {
+      await rm(base, { recursive: true, force: true })
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('allows a folder symlink that resolves back inside the workspace', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    try {
+      await mkdir(join(base, 'real'))
+      await symlink(join(base, 'real'), join(base, 'link'), isWin ? 'junction' : 'dir')
+      const saved = await saveImageToWorkspace({ workspaceRoot: base, folder: 'link', attachmentId: 'sha256:eeee5555', mediaType: 'image/png', data: new Uint8Array([5]) })
+      expect(saved.startsWith(resolve(base, 'link'))).toBe(true)
+      expect(new Uint8Array(await readFile(saved))).toEqual(new Uint8Array([5]))
+    } finally { await rm(base, { recursive: true, force: true }) }
+  })
+
+  it('does not report success when cancelled during the final rename', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    try {
+      const controller = new AbortController()
+      renameHooks.queue.push(() => controller.abort())
+      await expect(saveImageToWorkspace({ workspaceRoot: base, folder: undefined, attachmentId: 'sha256:ffff6666', mediaType: 'image/png', data: new Uint8Array([3]), signal: controller.signal })).rejects.toThrow()
+      // Neither the renamed image nor staging leftovers survive the cancel.
+      expect(await readdir(base)).toEqual([])
     } finally { await rm(base, { recursive: true, force: true }) }
   })
 })

--- a/tests/workspace-save.spec.ts
+++ b/tests/workspace-save.spec.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { saveImageToWorkspace, workspaceImageDir, workspaceImageName } from '../src/workspace-save.js'
+
+const FIXED_DATE = new Date(Date.UTC(2026, 0, 15, 8, 4, 9))
+const isWin = process.platform === 'win32'
+const root = isWin ? 'H:\\ws' : '/ws'
+const foreignAbs = isWin ? 'C:\\other' : '/etc'
+const parentTraversal = isWin ? '..\\escape' : '../escape'
+
+describe('workspaceImageName', () => {
+  it('builds a UTC-stamped, digest-suffixed name per media type', () => {
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/png', FIXED_DATE)).toBe('image-20260115-080409-01234567.png')
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/jpeg', FIXED_DATE)).toBe('image-20260115-080409-01234567.jpg')
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/webp', FIXED_DATE)).toBe('image-20260115-080409-01234567.webp')
+    expect(workspaceImageName('sha256:0123456789abcdef', 'image/gif', FIXED_DATE)).toBe('image-20260115-080409-01234567.gif')
+  })
+
+  it('accepts bare digests and pads short digests to eight chars', () => {
+    expect(workspaceImageName('abcdef', 'image/png', FIXED_DATE)).toBe('image-20260115-080409-abcdef00.png')
+    expect(workspaceImageName('abc', 'image/png', FIXED_DATE)).toBe('image-20260115-080409-abc00000.png')
+  })
+})
+
+describe('workspaceImageDir', () => {
+  it('defaults to the workspace root and keeps nested folders inside it', () => {
+    expect(workspaceImageDir(root, undefined)).toBe(root)
+    expect(workspaceImageDir(root, '')).toBe(root)
+    expect(workspaceImageDir(root, 'a/b')).toBe(resolve(root, 'a/b'))
+    expect(workspaceImageDir(root, '  dsh-image-gen  ')).toBe(resolve(root, 'dsh-image-gen'))
+  })
+
+  it('rejects folders that escape the workspace', () => {
+    expect(() => workspaceImageDir(root, parentTraversal)).toThrow(/must stay inside/)
+    expect(() => workspaceImageDir(root, 'a/../../escape')).toThrow(/must stay inside/)
+    expect(() => workspaceImageDir(root, foreignAbs)).toThrow(/must stay inside/)
+  })
+})
+
+describe('saveImageToWorkspace', () => {
+  it('writes the image bytes under the configured folder', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    try {
+      const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+      const saved = await saveImageToWorkspace({ workspaceRoot: base, folder: 'nested/deep', attachmentId: 'sha256:0123456789abcdef', mediaType: 'image/png', data: bytes })
+      expect(saved.startsWith(base)).toBe(true)
+      expect(saved.endsWith('.png')).toBe(true)
+      expect(new Uint8Array(await readFile(saved))).toEqual(bytes)
+      expect((await stat(saved)).isFile()).toBe(true)
+    } finally { await rm(base, { recursive: true, force: true }) }
+  })
+
+  it('writes into the workspace root when the folder is empty', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    try {
+      const saved = await saveImageToWorkspace({ workspaceRoot: base, folder: '', attachmentId: 'sha256:fedcba9876543210', mediaType: 'image/jpeg', data: new Uint8Array([1]) })
+      expect(saved.startsWith(base)).toBe(true)
+      expect(saved.endsWith('.jpg')).toBe(true)
+    } finally { await rm(base, { recursive: true, force: true }) }
+  })
+
+  it('overwrites the same content-addressed file instead of duplicating it', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    try {
+      const bytes = new Uint8Array([1, 2, 3])
+      const first = await saveImageToWorkspace({ workspaceRoot: base, folder: undefined, attachmentId: 'sha256:aaaa1111', mediaType: 'image/webp', data: bytes, signal: new AbortController().signal })
+      const second = await saveImageToWorkspace({ workspaceRoot: base, folder: undefined, attachmentId: 'sha256:aaaa1111', mediaType: 'image/webp', data: bytes, signal: new AbortController().signal })
+      expect(second).toBe(first)
+      expect(new Uint8Array(await readFile(first))).toEqual(bytes)
+    } finally { await rm(base, { recursive: true, force: true }) }
+  })
+
+  it('honours an already-aborted signal without writing', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'dsh-image-gen-'))
+    try {
+      const controller = new AbortController()
+      controller.abort()
+      await expect(saveImageToWorkspace({ workspaceRoot: base, folder: undefined, attachmentId: 'sha256:bbbb2222', mediaType: 'image/png', data: new Uint8Array([9]), signal: controller.signal })).rejects.toThrow()
+    } finally { await rm(base, { recursive: true, force: true }) }
+  })
+})


### PR DESCRIPTION
Images were persisted only to the DSH attachment store, so generated files were never visible in the user's workspace. Write each generated image as a file under the calling session's workspace and return the absolute path in the tool result and on the chat card.

- new settings: saveToWorkspace (default true) and workspaceFolder (empty = workspace root); the folder is validated to stay inside the workspace
- atomic write via staging file + rename; a workspace-write failure never discards the attached image (reported as saveError, logged)
- settings card gains the toggle and folder input; the result card shows the saved path
- 8 new unit tests; typecheck, test, build and pack:check all green

Bumps version to 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated images can now be saved automatically to the session workspace.
  * The save location can be disabled or customized in settings.
  * Image results display the saved file’s absolute path when available.
  * Added localized labels and status messaging for workspace saving.

* **Bug Fixes**
  * Improved protection against unsafe paths and incomplete files when saving is canceled or interrupted.

* **Documentation**
  * Updated English and Chinese documentation with workspace-saving details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->