### PR TITLE
feat: support multiple image edit references

### DIFF
--- a/src/dashscope.ts
+++ b/src/dashscope.ts
@@ -12,7 +12,7 @@ export interface DashScopeImageOptions {
 }
 
 export interface DashScopeEditOptions extends DashScopeImageOptions {
-  sourceImage: { data: Uint8Array; mediaType: ImageMediaType }
+  sourceImages: Array<{ data: Uint8Array; mediaType: ImageMediaType }>
 }
 
 interface DashScopeChoiceMessageContent {
@@ -65,7 +65,7 @@ export async function editDashScopeImage(options: DashScopeEditOptions): Promise
         messages: [{
           role: 'user',
           content: [
-            { image: toDataUrl(options.sourceImage) },
+            ...options.sourceImages.map(sourceImage => ({ image: toDataUrl(sourceImage) })),
             { text: options.prompt },
           ],
         }],

--- a/src/google.ts
+++ b/src/google.ts
@@ -33,18 +33,18 @@ export function generateGoogleImage(input: GoogleRequestBase & { prompt: string 
 /** Send one native Google image-editing request using already-resolved bytes. */
 export function editGoogleImage(input: GoogleRequestBase & {
   prompt: string
-  sourceImage: { data: Uint8Array; mediaType: ImageMediaType }
+  sourceImages: Array<{ data: Uint8Array; mediaType: ImageMediaType }>
 }): Promise<GeneratedImage> {
   return requestGoogleImage({
     ...input,
     operation: 'editing',
     interactionInput: [
       { type: 'text', text: input.prompt },
-      {
+      ...input.sourceImages.map(sourceImage => ({
         type: 'image',
-        mime_type: input.sourceImage.mediaType,
-        data: Buffer.from(input.sourceImage.data).toString('base64'),
-      },
+        mime_type: sourceImage.mediaType,
+        data: Buffer.from(sourceImage.data).toString('base64'),
+      })),
     ],
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { editDashScopeImage, generateDashScopeImage } from './dashscope.js'
 import { editGoogleImage, generateGoogleImage } from './google.js'
 import { IMAGE_ROUTE, imageAttachmentFromMeta, serveImage } from './image-route.js'
 import { editOpenAICompatibleImage, generateOpenAICompatibleImage } from './openai-compatible.js'
-import { resolveReferenceImage } from './reference-image.js'
+import { resolveReferenceImages } from './reference-image.js'
 import { editSeedreamImage } from './seedream.js'
 import { IMAGE_GENERATION_NAMESPACE } from './shared.js'
 import { saveImageToWorkspace } from './workspace-save.js'
@@ -74,11 +74,13 @@ export function apply(ctx: Context, config: Config = {}): void {
 
   ctx.tools.register(defineTool({
     name: 'edit_image',
-    description: 'Edit or restyle an existing image with the configured provider. For a named workspace file, pass its exact path as source_path. For a specific image still attached to the current conversation, pass source_attachment_id. Never provide both. Omit both only when the user clearly means the newest conversation image. If the user identifies an older image but its exact path or attachment id is unknown, do not silently edit the newest image: first use an image-reading tool to put the intended file into the conversation, then call edit_image without a source.',
+    description: 'Edit, combine, or restyle existing images with the configured provider. Images attached inline to the latest human message are already readable DSH attachments even when no workspace file exists. In that case, call edit_image immediately with prompt only; NEVER call read_image, glob, or shell to locate them, and NEVER invent @ paths. All inline images will be used in upload order. For specific older conversation images use source_attachment_id or source_attachment_ids; both canonical sha256: IDs and full bare SHA-256 digests are accepted. For files the user explicitly names in the workspace use source_path or source_paths. Provide exactly one selector field. Without a selector, images from the latest human message take priority; only when that message has no images does editing fall back to the newest conversation image.',
     parameters: {
       prompt: { type: 'string', required: true, description: 'Describe the changes to make while preserving everything else that should remain.' },
       source_attachment_id: { type: 'string', description: 'Optional attachment id of a specific image already present in the current conversation.' },
+      source_attachment_ids: { type: 'array', items: { type: 'string' }, description: 'Optional ordered attachment ids of multiple images already present in the current conversation. Prompt references such as image 1 and image 2 follow this order.' },
       source_path: { type: 'string', description: 'Optional absolute or workspace-relative path of a specific image file inside the active session workspace. Prefer this when the user names a saved file.' },
+      source_paths: { type: 'array', items: { type: 'string' }, description: 'Optional ordered absolute or workspace-relative paths of multiple image files inside the active session workspace.' },
       aspect_ratio: { type: 'string', enum: ['1:1', '3:2', '2:3', '4:3', '3:4', '16:9', '9:16'], description: 'Optional output aspect ratio for Google Gemini.' },
       image_size: { type: 'string', enum: ['1K', '2K', '4K'], description: 'Optional output resolution for Google Gemini.' },
       size: { type: 'string', description: 'Optional output size for OpenAI, Seedream, or DashScope.' },
@@ -88,11 +90,13 @@ export function apply(ctx: Context, config: Config = {}): void {
       const active = resolveProvider(current())
       const credential = await ctx.credentials.resolve(credentialRef(active.apiKeyEnv))
       if (credential === undefined || credential.value.length === 0) throw new Error(`edit_image requires the ${active.apiKeyEnv} credential; configure it in Settings > Plugins > Image generation.`)
-      const sourceImage = await resolveReferenceImage({
+      const sourceImages = await resolveReferenceImages({
         ...(exec.agent === undefined ? {} : { agent: exec.agent }),
         attachments: ctx.attachments,
         ...(typeof args.source_attachment_id === 'string' ? { sourceAttachmentId: args.source_attachment_id } : {}),
+        ...(Array.isArray(args.source_attachment_ids) ? { sourceAttachmentIds: args.source_attachment_ids } : {}),
         ...(typeof args.source_path === 'string' ? { sourcePath: args.source_path } : {}),
+        ...(Array.isArray(args.source_paths) ? { sourcePaths: args.source_paths } : {}),
         maxBytes: ctx.attachments.imageLimits.maxImageBytes,
         signal: exec.signal,
       })
@@ -100,20 +104,20 @@ export function apply(ctx: Context, config: Config = {}): void {
       if (active.provider === 'google') {
         const aspectRatio = (args.aspect_ratio ?? active.aspectRatio) as AspectRatio
         const imageSize = (args.image_size ?? active.imageSize) as ImageSize
-        const generated = await editGoogleImage({ apiKey: credential.value, endpoint: active.endpoint, model: active.model, prompt: args.prompt, sourceImage, aspectRatio, imageSize, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
+        const generated = await editGoogleImage({ apiKey: credential.value, endpoint: active.endpoint, model: active.model, prompt: args.prompt, sourceImages, aspectRatio, imageSize, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
         return saveGenerated(ctx, generated, active.provider, active.model, `${aspectRatio}, ${imageSize}`, current(), exec)
       }
 
       const size = args.size ?? active.imageSize
       if (active.provider === 'openai') {
-        const generated = await editOpenAICompatibleImage({ apiKey: credential.value, baseURL: active.baseURL, model: active.model, prompt: args.prompt, sourceImage, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
+        const generated = await editOpenAICompatibleImage({ apiKey: credential.value, baseURL: active.baseURL, model: active.model, prompt: args.prompt, sourceImages, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
         return saveGenerated(ctx, generated, active.provider, active.model, size, current(), exec)
       }
       if (active.provider === 'seedream') {
-        const generated = await editSeedreamImage({ apiKey: credential.value, baseURL: active.baseURL, model: active.model, prompt: args.prompt, sourceImage, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
+        const generated = await editSeedreamImage({ apiKey: credential.value, baseURL: active.baseURL, model: active.model, prompt: args.prompt, sourceImages, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
         return saveGenerated(ctx, generated, active.provider, active.model, size, current(), exec)
       }
-      const generated = await editDashScopeImage({ apiKey: credential.value, endpoint: active.endpoint, model: active.model, prompt: args.prompt, sourceImage, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
+      const generated = await editDashScopeImage({ apiKey: credential.value, endpoint: active.endpoint, model: active.model, prompt: args.prompt, sourceImages, size, maxBytes: ctx.attachments.imageLimits.maxImageBytes, signal: exec.signal })
       return saveGenerated(ctx, generated, active.provider, active.model, size, current(), exec)
     },
     presentResult: (_args, result) => imagePresentation(result),

--- a/src/openai-compatible.ts
+++ b/src/openai-compatible.ts
@@ -36,14 +36,17 @@ export async function editOpenAICompatibleImage(input: {
   baseURL: string
   model: string
   prompt: string
-  sourceImage: CompatibleReferenceImage
+  sourceImages: CompatibleReferenceImage[]
   size?: string
   maxBytes: number
   signal: AbortSignal
 }): Promise<GeneratedCompatibleImage> {
   const form = new FormData()
-  const uploadBytes = new Uint8Array(input.sourceImage.data)
-  form.append('image', new Blob([uploadBytes], { type: input.sourceImage.mediaType }), `reference.${extensionOf(input.sourceImage.mediaType)}`)
+  const imageField = input.sourceImages.length === 1 ? 'image' : 'image[]'
+  input.sourceImages.forEach((sourceImage, index) => {
+    const uploadBytes = new Uint8Array(sourceImage.data)
+    form.append(imageField, new Blob([uploadBytes], { type: sourceImage.mediaType }), `reference-${index + 1}.${extensionOf(sourceImage.mediaType)}`)
+  })
   form.append('prompt', input.prompt)
   form.append('model', input.model)
   if (input.size !== undefined && input.size.length > 0) form.append('size', input.size)

--- a/src/reference-image.ts
+++ b/src/reference-image.ts
@@ -41,33 +41,102 @@ export async function resolveReferenceImage(input: {
   maxBytes?: number
   signal: AbortSignal
 }): Promise<ResolvedReferenceImage> {
-  if (input.sourceAttachmentId !== undefined && input.sourcePath !== undefined) {
-    throw new Error('edit_image accepts either source_attachment_id or source_path, not both')
+  const images = await resolveReferenceImages(input)
+  const image = images[images.length - 1]
+  if (image === undefined) throw new Error('edit_image requires a reference image')
+  return image
+}
+
+/**
+ * Resolve one or more edit references while keeping every DSH-specific detail
+ * behind this compatibility boundary. Explicit selectors preserve caller order;
+ * without selectors, all images in the newest image-bearing message are used.
+ */
+export async function resolveReferenceImages(input: {
+  agent?: ReferenceImageAgent
+  attachments: ReferenceImageStore
+  sourceAttachmentId?: string
+  sourceAttachmentIds?: readonly string[]
+  sourcePath?: string
+  sourcePaths?: readonly string[]
+  maxBytes?: number
+  signal: AbortSignal
+}): Promise<ResolvedReferenceImage[]> {
+  const sourceAttachmentIds = mergeSelectors({
+    single: input.sourceAttachmentId,
+    multiple: input.sourceAttachmentIds,
+    singleName: 'source_attachment_id',
+    multipleName: 'source_attachment_ids',
+    equal: attachmentIdsEqual,
+  })
+  const sourcePaths = mergeSelectors({
+    single: input.sourcePath,
+    multiple: input.sourcePaths,
+    singleName: 'source_path',
+    multipleName: 'source_paths',
+    equal: (left, right) => left.trim() === right.trim(),
+  })
+  if (sourceAttachmentIds !== undefined && sourcePaths !== undefined) {
+    throw new Error('edit_image accepts only one of source_attachment_id, source_attachment_ids, source_path, or source_paths')
   }
 
-  if (input.sourcePath !== undefined) {
-    return readWorkspaceReferenceImage({
-      sourcePath: input.sourcePath,
+  if (sourcePaths !== undefined) {
+    return Promise.all(sourcePaths.map(sourcePath => readWorkspaceReferenceImage({
+      sourcePath,
       ...(input.agent?.session.header?.cwd === undefined ? {} : { workspaceRoot: input.agent.session.header.cwd }),
       ...(input.maxBytes === undefined ? {} : { maxBytes: input.maxBytes }),
       signal: input.signal,
-    })
+    })))
   }
 
   if (input.agent === undefined) {
     throw new Error('edit_image requires an active DSH agent session to resolve a reference image')
   }
 
-  const ref = findReferenceImage(input.agent.session.deriveMessages(), input.sourceAttachmentId)
-  if (ref === undefined) {
-    if (input.sourceAttachmentId !== undefined) {
-      throw new Error(`edit_image could not find image attachment ${input.sourceAttachmentId} in the current conversation`)
+  const refs = findReferenceImages(input.agent.session.deriveMessages(), sourceAttachmentIds)
+  if (refs.length === 0) {
+    if (sourceAttachmentIds !== undefined) {
+      throw new Error(`edit_image could not find image attachment ${sourceAttachmentIds[0]} in the current conversation`)
     }
     throw new Error('edit_image requires an image in the current conversation; upload or generate an image first')
   }
+  if (sourceAttachmentIds !== undefined && refs.length !== sourceAttachmentIds.length) {
+    const missing = sourceAttachmentIds.find(id => !refs.some(ref => attachmentIdsEqual(String(ref.attachmentId), id)))
+    throw new Error(`edit_image could not find image attachment ${missing ?? 'unknown'} in the current conversation`)
+  }
 
-  const stored = await input.attachments.readImage(ref, input.signal)
-  return { data: stored.data, mediaType: stored.ref.mediaType }
+  return Promise.all(refs.map(async ref => {
+    const stored = await input.attachments.readImage(ref, input.signal)
+    if (input.maxBytes !== undefined && stored.data.byteLength > input.maxBytes) {
+      throw new Error(`edit_image source image is too large (${stored.data.byteLength} bytes; maximum ${input.maxBytes})`)
+    }
+    return { data: stored.data, mediaType: stored.ref.mediaType }
+  }))
+}
+
+/** Find images in caller order, or every image in the newest image-bearing message. */
+export function findReferenceImages(
+  messages: readonly Message[],
+  sourceAttachmentIds?: readonly string[],
+): ImageAttachmentRef[] {
+  if (sourceAttachmentIds !== undefined) {
+    return sourceAttachmentIds.flatMap(id => {
+      const ref = findReferenceImage(messages, id)
+      return ref === undefined ? [] : [ref]
+    })
+  }
+
+  const latestHumanMessage = [...messages].reverse().find(message => message.source?.kind === 'user')
+  if (latestHumanMessage !== undefined) {
+    const refs = collectInBlocks(latestHumanMessage.content)
+    if (refs.length > 0) return refs
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const refs = collectInBlocks(messages[index]?.content ?? [])
+    if (refs.length > 0) return refs
+  }
+  return []
 }
 
 /**
@@ -165,7 +234,7 @@ function findInBlocks(
     const block = blocks[index]
     if (block === undefined) continue
     if (block.type === 'image') {
-      if (sourceAttachmentId === undefined || String(block.attachment.attachmentId) === sourceAttachmentId) {
+      if (sourceAttachmentId === undefined || attachmentIdsEqual(String(block.attachment.attachmentId), sourceAttachmentId)) {
         return block.attachment
       }
       continue
@@ -186,6 +255,48 @@ function parseDimensions(value: unknown): { width: number; height: number } | un
 
 function imageMediaType(value: unknown): value is ImageMediaType {
   return value === 'image/png' || value === 'image/jpeg' || value === 'image/webp' || value === 'image/gif'
+}
+
+function collectInBlocks(blocks: readonly ContentBlock[]): ImageAttachmentRef[] {
+  const refs: ImageAttachmentRef[] = []
+  for (const block of blocks) {
+    if (block.type === 'image') refs.push(block.attachment)
+    if (block.type === 'tool-result') refs.push(...collectInBlocks(block.content))
+  }
+  return refs
+}
+
+function attachmentIdsEqual(actual: string, requested: string): boolean {
+  if (actual === requested) return true
+  const actualDigest = sha256Digest(actual)
+  const requestedDigest = sha256Digest(requested)
+  return actualDigest !== undefined && actualDigest === requestedDigest
+}
+
+function sha256Digest(value: string): string | undefined {
+  const match = /^(?:sha256:)?([0-9a-f]{64})$/i.exec(value.trim())
+  return match?.[1]?.toLowerCase()
+}
+
+function mergeSelectors(input: {
+  single: string | undefined
+  multiple: readonly string[] | undefined
+  singleName: string
+  multipleName: string
+  equal: (left: string, right: string) => boolean
+}): readonly string[] | undefined {
+  if (input.multiple === undefined) {
+    return input.single === undefined ? undefined : [input.single]
+  }
+  if (input.multiple.length === 0) {
+    if (input.single !== undefined) return [input.single]
+    throw new Error(`edit_image ${input.multipleName} must not be empty`)
+  }
+  const single = input.single
+  if (single !== undefined && !input.multiple.some(value => input.equal(single, value))) {
+    throw new Error(`edit_image ${input.singleName} must also appear in ${input.multipleName} when both are provided`)
+  }
+  return input.multiple
 }
 
 function detectImageMediaType(data: Uint8Array): ImageMediaType | undefined {

--- a/src/seedream.ts
+++ b/src/seedream.ts
@@ -10,7 +10,7 @@ export async function editSeedreamImage(input: {
   baseURL: string
   model: string
   prompt: string
-  sourceImage: { data: Uint8Array; mediaType: ImageMediaType }
+  sourceImages: Array<{ data: Uint8Array; mediaType: ImageMediaType }>
   size?: string
   maxBytes: number
   signal: AbortSignal
@@ -21,7 +21,7 @@ export async function editSeedreamImage(input: {
     body: JSON.stringify({
       model: input.model,
       prompt: input.prompt,
-      image: [toDataUrl(input.sourceImage)],
+      image: input.sourceImages.map(toDataUrl),
       ...(input.size === undefined || input.size.length === 0 ? {} : { size: input.size }),
       response_format: 'b64_json',
     }),

--- a/tests/dashscope-edit.spec.ts
+++ b/tests/dashscope-edit.spec.ts
@@ -15,7 +15,10 @@ describe('editDashScopeImage', () => {
 
     await expect(editDashScopeImage({
       apiKey: 'dash-key', endpoint, model: 'qwen-image-3.0', prompt: 'add sunglasses',
-      sourceImage: { data: new Uint8Array(Buffer.from('source')), mediaType: 'image/png' },
+      sourceImages: [
+        { data: new Uint8Array(Buffer.from('source 1')), mediaType: 'image/png' },
+        { data: new Uint8Array(Buffer.from('source 2')), mediaType: 'image/jpeg' },
+      ],
       size: '1024*1024', maxBytes: 1024, signal,
     })).resolves.toEqual({ data: new Uint8Array([1, 2, 3]), mediaType: 'image/png' })
 
@@ -24,14 +27,15 @@ describe('editDashScopeImage', () => {
     const body = JSON.parse(init.body as string)
     expect(body.model).toBe('qwen-image-3.0')
     expect(body.input.messages[0].content[0].image).toMatch(/^data:image\/png;base64,/)
-    expect(body.input.messages[0].content[1]).toEqual({ text: 'add sunglasses' })
+    expect(body.input.messages[0].content[1].image).toMatch(/^data:image\/jpeg;base64,/)
+    expect(body.input.messages[0].content[2]).toEqual({ text: 'add sunglasses' })
     expect(body.parameters).toMatchObject({ prompt_extend: true, size: '1024*1024' })
   })
 
   it('rejects non-Qwen DashScope models instead of pretending they support editing', async () => {
     await expect(editDashScopeImage({
       apiKey: 'dash-key', endpoint, model: 'wanx2.1-t2i-turbo', prompt: 'edit',
-      sourceImage: { data: new Uint8Array([1]), mediaType: 'image/png' }, maxBytes: 1024, signal,
+      sourceImages: [{ data: new Uint8Array([1]), mediaType: 'image/png' }], maxBytes: 1024, signal,
     })).rejects.toThrow('Configure a qwen-image model.')
   })
 })

--- a/tests/google.spec.ts
+++ b/tests/google.spec.ts
@@ -36,7 +36,10 @@ describe('generateGoogleImage', () => {
       endpoint,
       model: 'gemini-3.1-flash-image',
       prompt: 'add black sunglasses',
-      sourceImage: { data: new Uint8Array(Buffer.from('source image')), mediaType: 'image/png' },
+      sourceImages: [
+        { data: new Uint8Array(Buffer.from('source image 1')), mediaType: 'image/png' },
+        { data: new Uint8Array(Buffer.from('source image 2')), mediaType: 'image/jpeg' },
+      ],
       aspectRatio: '1:1',
       imageSize: '1K',
       maxBytes: 1024,
@@ -48,7 +51,8 @@ describe('generateGoogleImage', () => {
       model: 'gemini-3.1-flash-image',
       input: [
         { type: 'text', text: 'add black sunglasses' },
-        { type: 'image', mime_type: 'image/png', data: Buffer.from('source image').toString('base64') },
+        { type: 'image', mime_type: 'image/png', data: Buffer.from('source image 1').toString('base64') },
+        { type: 'image', mime_type: 'image/jpeg', data: Buffer.from('source image 2').toString('base64') },
       ],
       response_format: { type: 'image', mime_type: 'image/jpeg', aspect_ratio: '1:1', image_size: '1K' },
     })

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -80,5 +80,16 @@ describe('image tool registration', () => {
     expect(parameters.properties).toHaveProperty('size')
     expect(parameters.properties).toHaveProperty('aspect_ratio')
     expect(parameters.properties).toHaveProperty('image_size')
+    expect(parameters.properties).toHaveProperty('source_attachment_ids')
+    expect(parameters.properties).toHaveProperty('source_paths')
+  })
+
+  it('tells the agent to use current inline attachments without workspace discovery', () => {
+    const { ctx, tools } = harnessContext()
+    apply(ctx, { provider: 'google', saveToWorkspace: false })
+    const edit = toolByName(tools, 'edit_image')
+
+    expect(edit.description).toContain('NEVER call read_image, glob, or shell')
+    expect(edit.description).toContain('call edit_image immediately with prompt only')
   })
 })

--- a/tests/openai-compatible.spec.ts
+++ b/tests/openai-compatible.spec.ts
@@ -20,7 +20,10 @@ describe('OpenAI-compatible images', () => {
 
     await expect(editOpenAICompatibleImage({
       apiKey: 'key', baseURL: 'https://api.openai.com/v1', model: 'gpt-image-2', prompt: 'add sunglasses',
-      sourceImage: { data: new Uint8Array(Buffer.from('source')), mediaType: 'image/png' },
+      sourceImages: [
+        { data: new Uint8Array(Buffer.from('source 1')), mediaType: 'image/png' },
+        { data: new Uint8Array(Buffer.from('source 2')), mediaType: 'image/jpeg' },
+      ],
       size: '1024x1024', maxBytes: 1024, signal,
     })).resolves.toEqual({ data: new Uint8Array(Buffer.from('edited image')), mediaType: 'image/png' })
 
@@ -32,7 +35,25 @@ describe('OpenAI-compatible images', () => {
     expect(form.get('model')).toBe('gpt-image-2')
     expect(form.get('prompt')).toBe('add sunglasses')
     expect(form.get('size')).toBe('1024x1024')
+    expect(form.getAll('image[]')).toHaveLength(2)
+    expect(form.getAll('image[]')[0]).toBeInstanceOf(Blob)
+  })
+
+  it('keeps the singular multipart image field for one reference', async () => {
+    const image = Buffer.from('edited image').toString('base64')
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ data: [{ b64_json: image }] }), { headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await editOpenAICompatibleImage({
+      apiKey: 'key', baseURL: 'https://relay.example/v1', model: 'image-model', prompt: 'edit',
+      sourceImages: [{ data: new Uint8Array([1]), mediaType: 'image/png' }],
+      maxBytes: 1024, signal,
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    const form = init.body as FormData
     expect(form.get('image')).toBeInstanceOf(Blob)
+    expect(form.getAll('image[]')).toHaveLength(0)
   })
 
   it('downloads Ark URL output with its declared media type', async () => {

--- a/tests/reference-image.spec.ts
+++ b/tests/reference-image.spec.ts
@@ -6,8 +6,10 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   findReferenceImage,
+  findReferenceImages,
   parseImageAttachmentRef,
   resolveReferenceImage,
+  resolveReferenceImages,
 } from '../src/reference-image.js'
 
 const signal = new AbortController().signal
@@ -25,6 +27,10 @@ function imageRef(id: string, mediaType: ImageAttachmentRef['mediaType'] = 'imag
 
 function messages(content: unknown[]): Message[] {
   return [{ role: 'assistant', content }] as unknown as Message[]
+}
+
+function sourcedMessage(content: unknown[], source: { kind: 'user' } | { kind: 'tool'; callId: string }): Message {
+  return { id: 'message-id', role: 'user', content, source } as unknown as Message
 }
 
 describe('reference image compatibility boundary', () => {
@@ -57,6 +63,109 @@ describe('reference image compatibility boundary', () => {
     expect(findReferenceImage(history, 'selected')).toBe(selected)
   })
 
+  it('collects every image from the newest image-bearing message in block order', () => {
+    const older = imageRef('older')
+    const first = imageRef('first')
+    const second = imageRef('second')
+    const history = [
+      ...messages([{ type: 'image', attachment: older }]),
+      ...messages([
+        { type: 'image', attachment: first },
+        { type: 'text', text: 'combine these' },
+        { type: 'tool-result', toolCallId: 'call-2', content: [{ type: 'image', attachment: second }] },
+      ]),
+    ]
+
+    expect(findReferenceImages(history)).toEqual([first, second])
+  })
+
+  it('resolves explicit attachment ids in caller order', async () => {
+    const first = imageRef('first', 'image/jpeg')
+    const second = imageRef('second', 'image/webp')
+    const readImage = vi.fn(async (ref: ImageAttachmentRef) => ({
+      ref,
+      data: new Uint8Array([String(ref.attachmentId) === 'second' ? 2 : 1]),
+    }))
+
+    await expect(resolveReferenceImages({
+      agent: { session: { deriveMessages: () => messages([
+        { type: 'image', attachment: first },
+        { type: 'image', attachment: second },
+      ]) } },
+      attachments: { readImage },
+      sourceAttachmentIds: ['second', 'first'],
+      signal,
+    })).resolves.toEqual([
+      { data: new Uint8Array([2]), mediaType: 'image/webp' },
+      { data: new Uint8Array([1]), mediaType: 'image/jpeg' },
+    ])
+    expect(readImage.mock.calls.map(([ref]) => String(ref.attachmentId))).toEqual(['second', 'first'])
+  })
+
+  it('accepts a redundant singular attachment selector already included in the plural selector', async () => {
+    const firstDigest = '4b859c853c4fdcdd236b54c846000fa6d049d1315e901035c127991c14836640'
+    const secondDigest = 'dd68082c844d269797d231f5acb2137075d89ba908966af8d5d4e9fd34b4eefc'
+    const first = imageRef(`sha256:${firstDigest}`)
+    const second = imageRef(`sha256:${secondDigest}`)
+    const readImage = vi.fn(async (ref: ImageAttachmentRef) => ({ ref, data: new Uint8Array([1]) }))
+
+    await expect(resolveReferenceImages({
+      agent: { session: { deriveMessages: () => messages([
+        { type: 'image', attachment: first },
+        { type: 'image', attachment: second },
+      ]) } },
+      attachments: { readImage },
+      sourceAttachmentId: firstDigest,
+      sourceAttachmentIds: [firstDigest, secondDigest],
+      signal,
+    })).resolves.toHaveLength(2)
+    expect(readImage.mock.calls.map(([ref]) => String(ref.attachmentId)))
+      .toEqual([`sha256:${firstDigest}`, `sha256:${secondDigest}`])
+  })
+
+  it('matches a bare SHA-256 digest to the canonical DSH attachment id', () => {
+    const digest = '4b859c853c4fdcdd236b54c846000fa6d049d1315e901035c127991c14836640'
+    const ref = imageRef(`sha256:${digest}`)
+
+    expect(findReferenceImages(messages([{ type: 'image', attachment: ref }]), [digest]))
+      .toEqual([ref])
+    expect(findReferenceImages(messages([{ type: 'image', attachment: ref }]), ['4b859c85']))
+      .toEqual([])
+  })
+
+  it('prefers images in the latest human message over later tool-read images', () => {
+    const cat = imageRef('cat')
+    const person = imageRef('person')
+    const unrelatedWorkspaceImage = imageRef('workspace-image')
+    const history = [
+      sourcedMessage([
+        { type: 'image', attachment: cat },
+        { type: 'image', attachment: person },
+        { type: 'text', text: 'replace the person with the cat' },
+      ], { kind: 'user' }),
+      sourcedMessage([{
+        type: 'tool-result',
+        toolCallId: 'read-call',
+        content: [{ type: 'image', attachment: unrelatedWorkspaceImage }],
+      }], { kind: 'tool', callId: 'read-call' }),
+    ]
+
+    expect(findReferenceImages(history)).toEqual([cat, person])
+  })
+
+  it('falls back to the newest generated or tool-read image when the current human message has no image', () => {
+    const generated = imageRef('generated')
+    const history = [
+      sourcedMessage([{
+        type: 'tool-result', toolCallId: 'generate-call',
+        content: [{ type: 'image', attachment: generated }],
+      }], { kind: 'tool', callId: 'generate-call' }),
+      sourcedMessage([{ type: 'text', text: 'add sunglasses to the last image' }], { kind: 'user' }),
+    ]
+
+    expect(findReferenceImages(history)).toEqual([generated])
+  })
+
   it('derives effective messages and reads the full durable reference', async () => {
     const ref = imageRef('source', 'image/webp')
     const deriveMessages = vi.fn(() => messages([{ type: 'image', attachment: ref }]))
@@ -75,6 +184,27 @@ describe('reference image compatibility boundary', () => {
     })
     expect(deriveMessages).toHaveBeenCalledOnce()
     expect(readImage).toHaveBeenCalledWith(ref, signal)
+  })
+
+  it('automatically resolves all images from the newest image-bearing message', async () => {
+    const first = imageRef('first', 'image/png')
+    const second = imageRef('second', 'image/jpeg')
+    const readImage = vi.fn(async (ref: ImageAttachmentRef) => ({
+      ref,
+      data: new Uint8Array([String(ref.attachmentId) === 'first' ? 1 : 2]),
+    }))
+
+    await expect(resolveReferenceImages({
+      agent: { session: { deriveMessages: () => messages([
+        { type: 'image', attachment: first },
+        { type: 'image', attachment: second },
+      ]) } },
+      attachments: { readImage },
+      signal,
+    })).resolves.toEqual([
+      { data: new Uint8Array([1]), mediaType: 'image/png' },
+      { data: new Uint8Array([2]), mediaType: 'image/jpeg' },
+    ])
   })
 
   it('fails clearly when the effective conversation has no image', async () => {
@@ -119,6 +249,36 @@ describe('reference image compatibility boundary', () => {
     expect(deriveMessages).not.toHaveBeenCalled()
   })
 
+  it('reads multiple workspace images in caller order', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'dsh-image-gen-workspace-'))
+    await writeFile(join(workspaceRoot, 'first.png'), new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1]))
+    await writeFile(join(workspaceRoot, 'second.jpg'), new Uint8Array([0xff, 0xd8, 0xff, 2]))
+
+    await expect(resolveReferenceImages({
+      agent: { session: { deriveMessages: () => [], header: { cwd: workspaceRoot } } },
+      attachments: { readImage: vi.fn() },
+      sourcePaths: ['second.jpg', 'first.png'],
+      signal,
+    })).resolves.toEqual([
+      { data: new Uint8Array([0xff, 0xd8, 0xff, 2]), mediaType: 'image/jpeg' },
+      { data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1]), mediaType: 'image/png' },
+    ])
+  })
+
+  it('accepts a redundant singular workspace path already included in source_paths', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'dsh-image-gen-workspace-'))
+    await writeFile(join(workspaceRoot, 'first.png'), new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    await writeFile(join(workspaceRoot, 'second.jpg'), new Uint8Array([0xff, 0xd8, 0xff]))
+
+    await expect(resolveReferenceImages({
+      agent: { session: { deriveMessages: () => [], header: { cwd: workspaceRoot } } },
+      attachments: { readImage: vi.fn() },
+      sourcePath: 'first.png',
+      sourcePaths: ['first.png', 'second.jpg'],
+      signal,
+    })).resolves.toHaveLength(2)
+  })
+
   it('does not fall back to the newest conversation image when source_path is missing', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'dsh-image-gen-workspace-'))
     const readImage = vi.fn()
@@ -158,6 +318,29 @@ describe('reference image compatibility boundary', () => {
       sourceAttachmentId: 'source',
       sourcePath: 'source.png',
       signal,
-    })).rejects.toThrow('either source_attachment_id or source_path')
+    })).rejects.toThrow('accepts only one of')
+  })
+
+  it('rejects conflicting singular and plural selectors of the same kind', async () => {
+    await expect(resolveReferenceImages({
+      attachments: { readImage: vi.fn() },
+      sourceAttachmentId: 'first',
+      sourceAttachmentIds: ['second'],
+      signal,
+    })).rejects.toThrow('source_attachment_id must also appear in source_attachment_ids')
+  })
+
+  it('rejects empty or partially missing explicit image lists', async () => {
+    const first = imageRef('first')
+    const base = {
+      agent: { session: { deriveMessages: () => messages([{ type: 'image', attachment: first }]) } },
+      attachments: { readImage: vi.fn() },
+      signal,
+    }
+
+    await expect(resolveReferenceImages({ ...base, sourceAttachmentIds: [] }))
+      .rejects.toThrow('must not be empty')
+    await expect(resolveReferenceImages({ ...base, sourceAttachmentIds: ['first', 'missing'] }))
+      .rejects.toThrow('could not find image attachment missing')
   })
 })

--- a/tests/seedream.spec.ts
+++ b/tests/seedream.spec.ts
@@ -13,7 +13,10 @@ describe('editSeedreamImage', () => {
 
     await expect(editSeedreamImage({
       apiKey: 'ark-key', baseURL: 'https://ark.cn-beijing.volces.com/api/v3', model: 'doubao-seedream-5-0-260128',
-      prompt: 'change the background', sourceImage: { data: new Uint8Array(Buffer.from('source')), mediaType: 'image/jpeg' },
+      prompt: 'change the background', sourceImages: [
+        { data: new Uint8Array(Buffer.from('source 1')), mediaType: 'image/jpeg' },
+        { data: new Uint8Array(Buffer.from('source 2')), mediaType: 'image/png' },
+      ],
       size: '2K', maxBytes: 1024, signal,
     })).resolves.toEqual({ data: new Uint8Array(Buffer.from('edited')), mediaType: 'image/png' })
 
@@ -24,8 +27,9 @@ describe('editSeedreamImage', () => {
     expect(body).toMatchObject({
       model: 'doubao-seedream-5-0-260128', prompt: 'change the background', size: '2K', response_format: 'b64_json',
     })
-    expect(body.image).toHaveLength(1)
+    expect(body.image).toHaveLength(2)
     expect(body.image[0]).toMatch(/^data:image\/jpeg;base64,/)
+    expect(body.image[1]).toMatch(/^data:image\/png;base64,/)
     expect(body.resolution).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- let edit_image consume every inline image from the latest human message in upload order
- add ordered attachment-id and workspace-path arrays while preserving single-image calls
- serialize multiple references for Google, OpenAI Images, Seedream, and DashScope
- normalize canonical and bare SHA-256 attachment IDs and tolerate redundant singular/plural selectors
- keep DSH session and attachment handling isolated in the reference-image compatibility boundary

## Validation

- pnpm run test: 56 tests passed
- pnpm run typecheck
- pnpm run build

Follow-up enhancement to the multi-image editing discussion in #6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image editing now supports combining multiple source images.
  * Select source images using attachment IDs or workspace paths.
  * Inline images can be used directly without additional image discovery.
  * Supports ordered image selection and common image formats across providers.

* **Bug Fixes**
  * Improved image reference matching, including digest-based attachment identification.
  * Added validation for missing, conflicting, duplicate, and oversized image selections.

* **Tests**
  * Expanded coverage for multi-image editing and reference resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->