### PR TITLE
feat: add local ComfyUI provider

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 # 🎨 dsh-image-gen
 
-**Bring ChatGPT-like conversational image generation and image editing to DeepSeek Harness, with support for text-to-image, image-to-image, continuous editing, and multiple image providers.**
+**Complete conversational image capabilities for DeepSeek Harness: text-to-image, image-to-image, multi-image references, continuous editing, local ComfyUI, and gallery management.**
 
 [![npm version](https://img.shields.io/npm/v/dsh-image-gen.svg?style=flat-square&color=blue)](https://www.npmjs.com/package/dsh-image-gen)
 [![DSH Plugin](https://img.shields.io/badge/Plugin%20For-DeepSeek%20Harness-6366f1?style=flat-square)](https://github.com/deepseek-ai)
@@ -27,7 +27,7 @@ Install the image generation plugin by running: pnpm dsh plugin --profile web ad
 
 <br />
 
-<p align="center">After installation, enter your API Key in DSH Settings, then tell the Agent:</p>
+<p align="center">After installation, enter your API key or configure local ComfyUI in DSH Settings, then tell the Agent:</p>
 
 ```text
 Draw a cyberpunk cat on a neon street in a rainy night.
@@ -56,7 +56,7 @@ DeepSeek Harness empowers agents to use tools for various tasks. This project ad
 graph LR
     A[User Prompt] --> B[DeepSeek Harness Agent]
     B --> C[generate_image / edit_image]
-    C --> D[Gemini / OpenAI / Seedream / DashScope]
+    C --> D[Gemini / OpenAI / Seedream / DashScope / ComfyUI]
     D --> E[Image Data]
     E --> F[In-chat Conversation Stream]
 ```
@@ -91,12 +91,12 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 
 </details>
 
-### 2. Configure API Key & Workspace Settings
+### 2. Configure Provider & Workspace Settings
 
 Open DSH Web (`http://localhost:3080`):
 
 1. Navigate to **Settings → Plugins → Image generation**.
-2. Select Provider, input API Key.
+2. Select a Provider. Enter an API key for cloud providers; for local ComfyUI, enter its URL and import an API Format Workflow JSON using `{{prompt}}` for the prompt and optional `{{seed}}` for the seed.
 3. Optionally enable **Save to workspace** (enabled by default) and specify subfolder, then click **Save**.
 
 <div align="center">
@@ -128,7 +128,7 @@ Click the **`[Gallery]`** Tab in the top navigation bar to browse and search all
 - 💬 **In-Chat Image Generation**: Tell your Agent what you want to draw without switching tabs or tools.
 - 🖼️ **Native Image Gallery**: Dedicated "Gallery" tab automatically collecting all generated images with keyword search, provider filtering, single-item deletion (with confirmation and persistent tombstones), and quick copy/download.
 - 🔍 **Interactive Image Tools**: High-res fullscreen preview, one-click copy to clipboard, local download, and open in new tab.
-- 🎨 **Multi-Provider Support**: Supports Google Gemini, OpenAI Images, OpenAI Compatible API, ByteDance Seedream / Volcengine Ark, and Aliyun DashScope (Wanx / Qwen-Image).
+- 🎨 **Multi-Provider Support**: Supports Google Gemini, OpenAI Images, OpenAI Compatible API, ByteDance Seedream / Volcengine Ark, Aliyun DashScope (Wanx / Qwen-Image), and local ComfyUI workflows.
 - 🔑 **BYOK (Bring Your Own Key)**: Uses your own API keys managed securely by DSH credentials service with write-only protection.
 - 🖼️ **Durable Session Persistence**: Images integrate with DSH Attachment and conversation lifecycle, preserved across reloads.
 - 💾 **Workspace File Output**: By default each generated image is also written as a file into the current session workspace; the tool result carries the absolute file path. Can be disabled or re-pointed in settings.
@@ -145,6 +145,7 @@ Click the **`[Gallery]`** Tab in the top navigation bar to browse and search all
 | **OpenAI Compatible** | Custom | Custom Base URL |
 | **ByteDance Seedream / Volcengine Ark** | `doubao-seedream-5-0-260128` | `https://ark.cn-beijing.volces.com/api/v3` |
 | **Aliyun DashScope / Wanx** | `wanx2.1-t2i-turbo` | `https://dashscope.aliyuncs.com/api/v1` |
+| **Local ComfyUI (text-to-image only)** | Imported API Format Workflow | `http://127.0.0.1:8188` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # 🎨 dsh-image-gen
 
-**让 DeepSeek Harness 拥有类似 ChatGPT 的原生对话生图与图片编辑能力，支持文生图、图生图、连续编辑，并兼容多家图像模型提供商。**
+**为 DeepSeek Harness 提供完整的对话图像能力：文生图、图生图、多图参考、连续编辑、本地 ComfyUI 与画廊管理。**
 
 [![npm version](https://img.shields.io/npm/v/dsh-image-gen.svg?style=flat-square&color=blue)](https://www.npmjs.com/package/dsh-image-gen)
 [![DSH Plugin](https://img.shields.io/badge/Plugin%20For-DeepSeek%20Harness-6366f1?style=flat-square)](https://github.com/deepseek-ai)
@@ -28,7 +28,7 @@
 
 <br />
 
-<p align="center">安装完成后，在 DSH 设置中填入自己的 API Key，就可以直接对 Agent 说：</p>
+<p align="center">安装完成后，在 DSH 设置中填入自己的 API Key 或配置本地 ComfyUI，就可以直接对 Agent 说：</p>
 
 ```text
 帮我画一张雨夜霓虹街头的赛博朋克猫咪。
@@ -57,7 +57,7 @@ DeepSeek Harness 已经可以让 Agent 调用不同工具完成任务，本项�
 graph LR
     A[用户 Prompt] --> B[DeepSeek Harness Agent]
     B --> C[generate_image / edit_image]
-    C --> D[Gemini / OpenAI / Seedream / DashScope]
+    C --> D[Gemini / OpenAI / Seedream / DashScope / ComfyUI]
     D --> E[图片数据]
     E --> F[当前 Conversation 对话流]
 ```
@@ -92,12 +92,12 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 
 </details>
 
-### 2. 配置 API Key 与工作区设置
+### 2. 配置 Provider 与工作区设置
 
 打开 DSH Web 页面（默认 `http://localhost:3080`）：
 
 1. 进入 **Settings → Plugins → Image generation**。
-2. 选择 Provider，填写 API Key。
+2. 选择 Provider；云端 Provider 填写 API Key，本地 ComfyUI 填写地址并导入 API Format Workflow JSON（提示词位置使用 `{{prompt}}`，种子可选用 `{{seed}}`）。
 3. 可按需开启 **保存到工作区**（默认开启）并自定义子目录，点击 **保存** 即可。
 
 <div align="center">
@@ -137,7 +137,7 @@ Agent 会调用 `edit_image`，复用当前会话中的图片继续修改。
 - 💬 **原生对话生图与编辑**：直接在 DeepSeek Harness 对话中生成图片，也可以基于已有图片继续修改。
 - 🔁 **连续多轮编辑**：支持复用当前会话中的上传图片、历史生成图和上一轮编辑结果继续迭代。
 - 🖼️ **画廊与图片工具**：自动汇总历史图片，支持搜索、筛选、全屏预览、复制、下载与删除。
-- 🎨 **多 Provider 支持**：兼容 Google Gemini、OpenAI Images / Compatible、Seedream、DashScope Qwen Image。
+- 🎨 **多 Provider 支持**：兼容 Google Gemini、OpenAI Images / Compatible、Seedream、DashScope Qwen Image，以及用户本地的 ComfyUI 工作流。
 - 🔑 **BYOK + 原生设置**：API Key、Provider、模型和 Endpoint 都可以直接在 DSH 设置中配置。
 - 💾 **会话与工作区保存**：图片接入 DSH Attachment / Conversation，并可自动保存到当前工作区。
 
@@ -152,6 +152,7 @@ Agent 会调用 `edit_image`，复用当前会话中的图片继续修改。
 | **OpenAI Compatible** | 自定义 | 自定义 Base URL |
 | **ByteDance Seedream / 火山方舟** | `doubao-seedream-5-0-260128` | `https://ark.cn-beijing.volces.com/api/v3` |
 | **Aliyun DashScope / Qwen Image** | `qwen-image-3.0` | `https://dashscope.aliyuncs.com/api/v1` |
+| **Local ComfyUI（仅文生图）** | 用户导入的 API Format Workflow | `http://127.0.0.1:8188` |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 # 🎨 dsh-image-gen
 
-**让 DeepSeek Harness 像 ChatGPT 一样在对话中直接生成图片，支持画廊汇总,全屏预览、快捷复制与一键下载。**
+**为 DeepSeek Harness 提供完整的对话图像能力：文生图、图生图、多图参考、连续编辑、本地 ComfyUI 与画廊管理。**
 
 [![npm version](https://img.shields.io/npm/v/dsh-image-gen.svg?style=flat-square&color=blue)](https://www.npmjs.com/package/dsh-image-gen)
 [![DSH Plugin](https://img.shields.io/badge/Plugin%20For-DeepSeek%20Harness-6366f1?style=flat-square)](https://github.com/deepseek-ai)
@@ -27,7 +27,7 @@
 
 <br />
 
-<p align="center">安装完成后，在 DSH 设置中填入自己的 API Key，就可以直接对 Agent 说：</p>
+<p align="center">安装完成后，在 DSH 设置中填入自己的 API Key 或配置本地 ComfyUI，就可以直接对 Agent 说：</p>
 
 ```text
 帮我画一张雨夜霓虹街头的赛博朋克猫咪。
@@ -53,7 +53,7 @@ DeepSeek Harness 已经可以让 Agent 调用不同工具完成任务，本项�
 graph LR
     A[用户 Prompt] --> B[DeepSeek Harness Agent]
     B --> C[generate_image 工具]
-    C --> D[Gemini / OpenAI / Seedream / DashScope]
+    C --> D[Gemini / OpenAI / Seedream / DashScope / ComfyUI]
     D --> E[图片数据]
     E --> F[当前 Conversation 对话流]
 ```
@@ -88,12 +88,12 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 
 </details>
 
-### 2. 配置 API Key 与工作区设置
+### 2. 配置 Provider 与工作区设置
 
 打开 DSH Web 页面（默认 `http://localhost:3080`）：
 
 1. 进入 **Settings → Plugins → Image generation**。
-2. 选择 Provider，填写 API Key。
+2. 选择 Provider；云端 Provider 填写 API Key，本地 ComfyUI 填写地址并导入 API Format Workflow JSON（提示词位置使用 `{{prompt}}`，种子可选用 `{{seed}}`）。
 3. 可按需开启 **保存到工作区**（默认开启）并自定义子目录，点击 **保存** 即可。
 
 <div align="center">
@@ -125,7 +125,7 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 - 💬 **对话中直接生图**：不需要切换到其他网站，也不需要手动复制 Prompt，直接告诉 Agent 你想画什么即可。
 - 🖼️ **历史生图画廊**：顶栏自带「画廊」Tab，自动汇总所有历史生成的图片，支持关键词搜索、厂商筛选、单张删除（带防误触确认与持久化墓碑）与一键复制/下载。
 - 🔍 **交互式图片工具**：支持点击全屏大图预览、一键复制图片到剪贴板、本地下载与新标签页打开。
-- 🎨 **多 Provider 支持**：支持 Google Gemini、OpenAI Images、OpenAI Compatible API、ByteDance Seedream / 火山方舟以及阿里云 DashScope（通义万相 / Qwen-Image）。Provider、模型和 Endpoint 均可在设置中自由定制。
+- 🎨 **多 Provider 支持**：支持 Google Gemini、OpenAI Images、OpenAI Compatible API、ByteDance Seedream / 火山方舟、阿里云 DashScope（通义万相 / Qwen-Image）以及用户本地的 ComfyUI 工作流。
 - 🔑 **BYOK (自带 Key)**：插件使用你自己的 API Key。API Key 通过 DeepSeek Harness 的 `credentials` 服务管理，采用写保护隔离，不需要写进项目源码或配置文件，前端不存明文。
 - 🖼️ **图片跟随会话保存**：生成结果会接入 DeepSeek Harness 的 Attachment / Conversation 体系，重新打开历史会话后，仍然可以看到之前生成的图片。
 - 💾 **生成图片自动落盘到工作区**：默认在每次生成后把图片文件保存到当前会话工作区，工具结果会返回文件的绝对路径；可在设置中关闭或修改保存目录。
@@ -142,6 +142,7 @@ pnpm dsh plugin --profile web add ./dsh-image-gen
 | **OpenAI Compatible** | 自定义 | 自定义 Base URL |
 | **ByteDance Seedream / 火山方舟** | `doubao-seedream-5-0-260128` | `https://ark.cn-beijing.volces.com/api/v3` |
 | **Aliyun DashScope / 通义万相** | `wanx2.1-t2i-turbo` | `https://dashscope.aliyuncs.com/api/v1` |
+| **Local ComfyUI（仅文生图）** | 用户导入的 API Format Workflow | `http://127.0.0.1:8188` |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-image-gen",
   "version": "0.2.1",
-  "description": "Bring ChatGPT-like image generation to DeepSeek Harness — Gemini, OpenAI, Seedream, DashScope & more.",
+  "description": "Bring ChatGPT-like image generation to DeepSeek Harness — Gemini, OpenAI, Seedream, DashScope, local ComfyUI & more.",
   "type": "module",
   "author": "shanliuling",
   "repository": {
@@ -79,6 +79,8 @@
     "openai-compatible",
     "seedream",
     "dashscope",
+    "comfyui",
+    "local-image-generation",
     "wanx",
     "aliyun",
     "volcengine",

--- a/skills/install-dsh-image-gen/SKILL.md
+++ b/skills/install-dsh-image-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-dsh-image-gen
-description: Install, configure, verify, or remove the dsh-image-gen Bundle in a DeepSeek Harness Web profile. Use when a user wants Google, OpenAI-compatible relay, or Seedream image generation in DSH, cannot find the Image generation settings card, or needs help testing generate_image.
+description: Install, configure, verify, or remove the dsh-image-gen Bundle in a DeepSeek Harness Web profile. Use when a user wants Google, OpenAI-compatible relay, Seedream, DashScope, or local ComfyUI image generation in DSH, cannot find the Image generation settings card, or needs help testing generate_image.
 ---
 
 # Install DSH Image Gen
@@ -16,7 +16,7 @@ description: Install, configure, verify, or remove the dsh-image-gen Bundle in a
 4. If pnpm blocks the Git dependency's `prepare` script, explain that the allowance executes repository code during installation. Add only the exact package key pnpm reports to the profile's `pnpm-workspace.yaml`, then retry after the user approves.
 5. Verify `dsh --profile <profile> --dump-config` contains the `dsh-image-gen` layer and `image-gen` row.
 6. Start the profile. If port 3080 is already in use, identify the existing DSH process before stopping anything.
-7. In Settings > Plugins > Plugin configuration > Image generation, select Google, OpenAI-compatible relay, or Seedream, then save its API key. Never print, read back, or commit the key.
+7. In Settings > Plugins > Plugin configuration > Image generation, select a cloud Provider and save its API key, or select Local ComfyUI, enter its URL, and import a ComfyUI API Format workflow JSON containing `{{prompt}}`. Never print, read back, or commit a key.
 8. Test with “生成一张戴墨镜的赛博朋克猫图片”. Confirm one `generate_image` call succeeds and its image renders in the conversation.
 
 For removal, run `dsh plugin --profile <profile> remove dsh-image-gen`. Do not delete the user's credentials unless they explicitly request it.

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,8 +1,7 @@
 /** Web settings and generated-image cards contributed by the Bundle. */
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react'
 import type { Context } from '@deepseek-ai/cordis'
 import type { ImageAttachmentRef } from '@deepseek-ai/dsh-attachment'
-import type { ConnectionHandle } from '@deepseek-ai/dsh-client-connection/client'
 import type { SettingsScope, ToolCallBlock } from '@deepseek-ai/dsh-client-runtime/client'
 import type { InjectFace, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
 import type {} from '@deepseek-ai/dsh-api-remotes/client'
@@ -11,11 +10,14 @@ import type {} from '@deepseek-ai/dsh-client-ui-settings-plugins/client'
 import type {} from '@deepseek-ai/dsh-client-ui-tool/client'
 import {
   DEFAULT_BASE_URLS,
+  DEFAULT_COMFYUI_TIMEOUT_MS,
   DEFAULT_MODELS,
   IMAGE_GENERATION_NAMESPACE,
   IMAGE_ROUTE,
+  MAX_COMFYUI_WORKFLOW_BYTES,
   type ImageProvider,
 } from '../shared.js'
+import { validateComfyUIWorkflowJson } from '../comfyui-workflow.js'
 import { saveGalleryItem } from './gallery-store.js'
 import { GalleryViewTab, copyImageBlob, type LocaleService } from './gallery-view.js'
 
@@ -30,15 +32,26 @@ interface ImageSettings {
   seedreamModel?: string
   dashscopeEndpoint?: string
   dashscopeModel?: string
+  comfyuiBaseURL?: string
+  comfyuiWorkflowJson?: string
+  comfyuiWorkflowName?: string
+  comfyuiTimeoutMs?: number
   saveToWorkspace?: boolean
   workspaceFolder?: string
 }
-interface SettingsFace { scope: SettingsScope<ImageSettings>; credentials: ConnectionHandle['api']['credentials']; locale?: LocaleService | undefined }
+interface CredentialInfo { configured?: boolean }
+interface CredentialResult { ok: boolean; value?: Readonly<Record<string, CredentialInfo>> }
+interface CredentialMutationResult { ok: boolean; error?: { message?: string } }
+interface CredentialsRemote {
+  describe(refs: string[]): Promise<CredentialResult>
+  set(ref: string, value: string): Promise<CredentialMutationResult>
+}
+interface SettingsFace { scope: SettingsScope<ImageSettings>; credentials: CredentialsRemote; locale?: LocaleService | undefined }
 interface ImageCardFace { locale?: LocaleService | undefined }
 type SettingsCardProps = PropsRuntime<'settings.plugin.item'> & InjectFace<SettingsFace>
 type ImageCardProps = PropsRuntime<'tool.call.toolview'> & InjectFace<ImageCardFace>
 
-const KEY_REF: Record<Provider, string> = {
+const KEY_REF: Partial<Record<Provider, string>> = {
   google: 'GEMINI_API_KEY',
   openai: 'OPENAI_API_KEY',
   seedream: 'ARK_API_KEY',
@@ -54,6 +67,7 @@ const DICT = {
     providerOpenAI: 'OpenAI / 中转站',
     providerSeedream: '字节 Seedream',
     providerDashScope: '阿里 DashScope (通义万相 / Qwen)',
+    providerComfyUI: '本地 ComfyUI',
     apiKeyLabel: '{provider} API Key',
     apiKeyPlaceholder: '留空即可保留已配置的 Key',
     apiKeyHint: '安全保存为 {key}；页面不会读回明文。',
@@ -64,7 +78,17 @@ const DICT = {
     endpointHintOpenAI: '中转站请填其 OpenAI 兼容的 /v1 地址。',
     endpointHintSeedream: '火山方舟兼容的 /api/v3 地址。',
     endpointHintDashScope: '阿里云百炼 DashScope 官方接口地址。',
+    endpointHintComfyUI: '正在运行且 DSH Host 可以访问的 ComfyUI 地址，默认使用本机 8188 端口。',
     model: '模型',
+    workflow: 'API Workflow',
+    workflowImport: '导入 JSON 文件',
+    workflowReplace: '替换 JSON 文件',
+    workflowMissing: '尚未导入工作流',
+    workflowImported: '已导入 {name}',
+    workflowHint: '请从 ComfyUI 导出 API Format JSON，并在提示词输入位置写入 {{prompt}}；可用 {{seed}} 作为随机种子。',
+    workflowTooLarge: '工作流文件不能超过 5 MB。',
+    timeout: '生成超时（秒）',
+    timeoutHint: '包括提交、等待和下载图片；默认 300 秒。',
     saveToWorkspace: '保存到工作区',
     saveToWorkspaceHint: '每次生成后，把图片文件保存到当前会话工作区。',
     folder: '工作区文件夹',
@@ -94,6 +118,7 @@ const DICT = {
     providerOpenAI: 'OpenAI / Relay',
     providerSeedream: 'ByteDance Seedream',
     providerDashScope: 'Aliyun DashScope (Wanx / Qwen)',
+    providerComfyUI: 'Local ComfyUI',
     apiKeyLabel: '{provider} API Key',
     apiKeyPlaceholder: 'Leave empty to keep configured key',
     apiKeyHint: 'Securely saved as {key}; never read back in plaintext.',
@@ -104,7 +129,17 @@ const DICT = {
     endpointHintOpenAI: 'OpenAI-compatible /v1 base URL for relays.',
     endpointHintSeedream: 'Volcengine Ark compatible /api/v3 base URL.',
     endpointHintDashScope: 'Official Aliyun DashScope endpoint.',
+    endpointHintComfyUI: 'A running ComfyUI server reachable by the DSH Host; the default points to port 8188 on this computer.',
     model: 'Model',
+    workflow: 'API Workflow',
+    workflowImport: 'Import JSON file',
+    workflowReplace: 'Replace JSON file',
+    workflowMissing: 'No workflow imported',
+    workflowImported: 'Imported {name}',
+    workflowHint: 'Export an API Format JSON from ComfyUI and place {{prompt}} in its prompt input. {{seed}} is available for a random seed.',
+    workflowTooLarge: 'Workflow files must be no larger than 5 MB.',
+    timeout: 'Generation timeout (seconds)',
+    timeoutHint: 'Covers submission, waiting, and image download; defaults to 300 seconds.',
     saveToWorkspace: 'Save to workspace',
     saveToWorkspaceHint: 'Write each generated image as a file into the session workspace.',
     folder: 'Workspace folder',
@@ -147,6 +182,12 @@ const STYLE = `
 .dsh-ig-input{box-sizing:border-box;width:100%;padding:8px 12px;font-size:13px;border:1px solid var(--dsw-alias-border-l2,#d7dbe0);border-radius:8px;background:var(--dsw-alias-bg-layer-3,transparent);color:inherit;outline:none;transition:border-color .15s}
 .dsh-ig-input:focus{border-color:var(--dsw-alias-brand-primary,#4c78ff)}
 .dsh-ig-input-group{display:flex;gap:8px;align-items:center}
+.dsh-ig-file-row{display:flex;align-items:center;gap:10px;min-width:0}
+.dsh-ig-file-input{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;clip-path:inset(50%)}
+.dsh-ig-file-button{appearance:none;flex:none;border:1px solid var(--dsw-alias-border-l2,#d7dbe0);border-radius:8px;padding:7px 12px;background:var(--dsw-alias-bg-layer-3,#f9fafb);color:var(--dsw-alias-label-secondary,inherit);font-size:13px;cursor:pointer;transition:background .15s,border-color .15s}
+.dsh-ig-file-button:hover{background:var(--dsw-alias-bg-layer-2,#edf0f3);border-color:var(--dsw-alias-label-dimmed,#9ca3af)}
+.dsh-ig-file-button:focus-within{outline:2px solid var(--dsw-alias-brand-primary,#4c78ff);outline-offset:2px}
+.dsh-ig-file-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--dsw-alias-label-secondary,inherit);font-size:12px}
 .dsh-ig-btn-reset{appearance:none;border:1px solid var(--dsw-alias-border-l2,#d7dbe0);border-radius:8px;padding:7px 12px;background:var(--dsw-alias-bg-layer-3,#f9fafb);color:var(--dsw-alias-label-secondary,inherit);font:inherit;font-size:13px;cursor:pointer;white-space:nowrap;transition:background .15s,border-color .15s}
 .dsh-ig-btn-reset:hover{background:var(--dsw-alias-bg-layer-2,#edf0f3);border-color:var(--dsw-alias-label-dimmed,#9ca3af)}
 .dsh-ig-hint,.dsh-ig-status{margin:0;color:var(--dsw-alias-label-tertiary,#7b818b);font-size:12px;line-height:1.4}
@@ -228,13 +269,13 @@ const STYLE = `
 `
 
 /** Required browser services. */
-export const inject = ['slots', 'connection', 'remote', 'settingsScope', 'locale']
+export const inject = ['slots', 'remote', 'remote.credentials', 'settingsScope', 'locale']
 
 /** Mount the settings card, generated-image card, and native conversation gallery view. */
 export function apply(ctx: Context): void {
-  const { api } = ctx.get('connection') as ConnectionHandle
   const scope = ctx.settingsScope.bind<ImageSettings>({ namespace: IMAGE_GENERATION_NAMESPACE as never })
   const locale = ctx.get('locale') as LocaleService | undefined
+  const credentials = (ctx as Context & { remote: { credentials: CredentialsRemote } }).remote.credentials
 
   ctx.effect(() => {
     const style = document.createElement('style')
@@ -252,7 +293,7 @@ export function apply(ctx: Context): void {
   ctx.slots.inject('settings.plugin.item', () => register({
     name: 'settings.plugin.item',
     key: IMAGE_GENERATION_NAMESPACE,
-    inject: (): SettingsFace => ({ scope, credentials: api.credentials, locale }),
+    inject: (): SettingsFace => ({ scope, credentials, locale }),
   }, ImageGenerationSettingsCard))
 
   // 2. Tool result view card in chat stream
@@ -288,6 +329,9 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
   const [provider, setProvider] = useState<Provider>('google')
   const [model, setModel] = useState('')
   const [baseURL, setBaseURL] = useState('')
+  const [workflowJson, setWorkflowJson] = useState('')
+  const [workflowName, setWorkflowName] = useState('')
+  const [timeoutSeconds, setTimeoutSeconds] = useState(DEFAULT_COMFYUI_TIMEOUT_MS / 1000)
   const [saveToWorkspace, setSaveToWorkspace] = useState(true)
   const [workspaceFolder, setWorkspaceFolder] = useState('dsh-image-gen')
   const [key, setKey] = useState('')
@@ -318,20 +362,29 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
     openai: t('providerOpenAI'),
     seedream: t('providerSeedream'),
     dashscope: t('providerDashScope'),
+    comfyui: t('providerComfyUI'),
   }
 
   useEffect(() => {
     const value = snapshot.value
     const next = value?.provider ?? 'google'
     setProvider(next); setModel(modelOf(next, value)); setBaseURL(baseURLOf(next, value))
+    setWorkflowJson(value?.comfyuiWorkflowJson ?? '')
+    setWorkflowName(value?.comfyuiWorkflowName ?? '')
+    setTimeoutSeconds(Math.max(1, Math.round((value?.comfyuiTimeoutMs ?? DEFAULT_COMFYUI_TIMEOUT_MS) / 1000)))
     setSaveToWorkspace(value?.saveToWorkspace ?? true)
     setWorkspaceFolder(value?.workspaceFolder ?? 'dsh-image-gen')
   }, [snapshot])
 
   useEffect(() => {
+    const keyRef = KEY_REF[provider]
+    if (keyRef === undefined) {
+      setConfigured(undefined)
+      return
+    }
     let active = true
-    void props.credentials.describe({ refs: [KEY_REF[provider]] }).then(response => {
-      if (active) setConfigured(response.result.ok ? response.result.value.credentials[KEY_REF[provider]]?.configured ?? false : undefined)
+    void props.credentials.describe([keyRef]).then(response => {
+      if (active) setConfigured(response.ok ? response.value?.[keyRef]?.configured ?? false : undefined)
     }).catch(() => { if (active) setConfigured(undefined) })
     return () => { active = false }
   }, [props.credentials, provider])
@@ -340,13 +393,23 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
     event.preventDefault(); setSaving(true); setMessage('')
     try {
       await props.scope.set('provider', provider)
-      await props.scope.set(provider === 'google' ? 'googleModel' : provider === 'openai' ? 'openaiModel' : provider === 'seedream' ? 'seedreamModel' : 'dashscopeModel', model)
-      await props.scope.set(provider === 'google' ? 'googleEndpoint' : provider === 'openai' ? 'openaiBaseURL' : provider === 'seedream' ? 'seedreamBaseURL' : 'dashscopeEndpoint', baseURL)
+      if (provider === 'comfyui') {
+        validateComfyUIWorkflowJson(workflowJson)
+        await props.scope.set('comfyuiBaseURL', baseURL)
+        await props.scope.set('comfyuiWorkflowJson', workflowJson)
+        await props.scope.set('comfyuiWorkflowName', workflowName)
+        await props.scope.set('comfyuiTimeoutMs', Math.max(1, Math.round(timeoutSeconds)) * 1000)
+      } else {
+        await props.scope.set(provider === 'google' ? 'googleModel' : provider === 'openai' ? 'openaiModel' : provider === 'seedream' ? 'seedreamModel' : 'dashscopeModel', model)
+        await props.scope.set(provider === 'google' ? 'googleEndpoint' : provider === 'openai' ? 'openaiBaseURL' : provider === 'seedream' ? 'seedreamBaseURL' : 'dashscopeEndpoint', baseURL)
+      }
       await props.scope.set('saveToWorkspace', saveToWorkspace)
       await props.scope.set('workspaceFolder', workspaceFolder.trim())
       if (key.trim().length > 0) {
-        const response = await props.credentials.set({ ref: KEY_REF[provider], value: key.trim() })
-        if (!response.result.ok) throw new Error(response.result.error.message)
+        const keyRef = KEY_REF[provider]
+        if (keyRef === undefined) throw new Error('ComfyUI does not use an API key in this version')
+        const response = await props.credentials.set(keyRef, key.trim())
+        if (!response.ok) throw new Error(response.error?.message ?? 'Failed to save API key')
         setKey(''); setConfigured(true)
       }
       setMessage(t('saved'))
@@ -354,6 +417,24 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
   }
 
   const keyStatus = configured === undefined ? t('checkingKey') : configured ? t('keyConfigured') : t('keyNotConfigured')
+  const workflowStatus = workflowName.length > 0 ? t('workflowImported', { name: workflowName }) : t('workflowMissing')
+
+  const importWorkflow = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (file === undefined) return
+    setMessage('')
+    try {
+      if (file.size > MAX_COMFYUI_WORKFLOW_BYTES) throw new Error(t('workflowTooLarge'))
+      const json = await file.text()
+      validateComfyUIWorkflowJson(json)
+      setWorkflowJson(json)
+      setWorkflowName(file.name)
+      setMessage(t('workflowImported', { name: file.name }))
+    } catch (cause) {
+      setMessage(cause instanceof Error ? cause.message : String(cause))
+    }
+  }
 
   return (
     <li className={`dsh-ig-card ${open ? 'dsh-ig-card-open' : ''}`}>
@@ -375,26 +456,46 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
               <option value="openai">{t('providerOpenAI')}</option>
               <option value="seedream">{t('providerSeedream')}</option>
               <option value="dashscope">{t('providerDashScope')}</option>
+              <option value="comfyui">{t('providerComfyUI')}</option>
             </select>
             <span className="dsh-ig-hint">{providerLabels[provider]}</span>
           </label>
-          <label className="dsh-ig-field">
+          {provider !== 'comfyui' ? <label className="dsh-ig-field">
             <span className="dsh-ig-label">{t('apiKeyLabel', { provider: providerLabels[provider] })}</span>
             <input className="dsh-ig-input" type="password" autoComplete="off" value={key} onChange={event => { setKey(event.target.value) }} placeholder={configured ? t('apiKeyPlaceholder') : ''} />
-            <span className="dsh-ig-hint">{t('apiKeyHint', { key: KEY_REF[provider] })}</span>
-          </label>
+            <span className="dsh-ig-hint">{t('apiKeyHint', { key: KEY_REF[provider] ?? '' })}</span>
+          </label> : null}
           <label className="dsh-ig-field">
             <span className="dsh-ig-label">{t('endpoint')}</span>
             <div className="dsh-ig-input-group">
               <input className="dsh-ig-input" type="url" value={baseURL} onChange={event => { setBaseURL(event.target.value) }} required />
               <button type="button" className="dsh-ig-btn-reset" title={t('resetTitle')} onClick={() => { setBaseURL(DEFAULT_BASE_URLS[provider]) }}>{t('reset')}</button>
             </div>
-            <span className="dsh-ig-hint">{provider === 'google' ? t('endpointHintGoogle') : provider === 'openai' ? t('endpointHintOpenAI') : provider === 'seedream' ? t('endpointHintSeedream') : t('endpointHintDashScope')}</span>
+            <span className="dsh-ig-hint">{provider === 'google' ? t('endpointHintGoogle') : provider === 'openai' ? t('endpointHintOpenAI') : provider === 'seedream' ? t('endpointHintSeedream') : provider === 'dashscope' ? t('endpointHintDashScope') : t('endpointHintComfyUI')}</span>
           </label>
-          <label className="dsh-ig-field">
+          {provider !== 'comfyui' ? <label className="dsh-ig-field">
             <span className="dsh-ig-label">{t('model')}</span>
             <input className="dsh-ig-input" value={model} onChange={event => { setModel(event.target.value) }} required />
-          </label>
+          </label> : (
+            <>
+              <div className="dsh-ig-field">
+                <span className="dsh-ig-label">{t('workflow')}</span>
+                <div className="dsh-ig-file-row">
+                  <label className="dsh-ig-file-button">
+                    <input className="dsh-ig-file-input" type="file" accept=".json,application/json" onChange={event => { void importWorkflow(event) }} />
+                    {workflowName.length > 0 ? t('workflowReplace') : t('workflowImport')}
+                  </label>
+                  <span className="dsh-ig-file-name" title={workflowName}>{workflowName || t('workflowMissing')}</span>
+                </div>
+                <span className="dsh-ig-hint">{t('workflowHint')}</span>
+              </div>
+              <label className="dsh-ig-field">
+                <span className="dsh-ig-label">{t('timeout')}</span>
+                <input className="dsh-ig-input" type="number" min="1" max="3600" step="1" value={timeoutSeconds} onChange={event => { setTimeoutSeconds(Number(event.target.value)) }} required />
+                <span className="dsh-ig-hint">{t('timeoutHint')}</span>
+              </label>
+            </>
+          )}
           <div className="dsh-ig-field">
             <label className="dsh-ig-check-row">
               <input type="checkbox" checked={saveToWorkspace} onChange={event => { setSaveToWorkspace(event.target.checked) }} />
@@ -410,8 +511,8 @@ export function ImageGenerationSettingsCard(props: SettingsCardProps) {
             </label>
           ) : null}
           <div className="dsh-ig-actions">
-            <p className="dsh-ig-status" role="status">{message || keyStatus}</p>
-            <button className="dsh-ig-save" type="submit" disabled={saving || !snapshot.writable}>{saving ? t('saving') : t('save')}</button>
+            <p className="dsh-ig-status" role="status">{message || (provider === 'comfyui' ? workflowStatus : keyStatus)}</p>
+            <button className="dsh-ig-save" type="submit" disabled={saving || !snapshot.writable || (provider === 'comfyui' && workflowJson.length === 0)}>{saving ? t('saving') : t('save')}</button>
           </div>
         </form>
       ) : null}
@@ -570,12 +671,12 @@ export function GeneratedImageCard(props: ImageCardProps) {
 }
 
 function modelOf(provider: Provider, value: ImageSettings | undefined): string {
-  const stored = provider === 'google' ? value?.googleModel : provider === 'openai' ? value?.openaiModel : provider === 'seedream' ? value?.seedreamModel : value?.dashscopeModel
+  const stored = provider === 'google' ? value?.googleModel : provider === 'openai' ? value?.openaiModel : provider === 'seedream' ? value?.seedreamModel : provider === 'dashscope' ? value?.dashscopeModel : value?.comfyuiWorkflowName
   return typeof stored === 'string' && stored.length > 0 ? stored : DEFAULT_MODELS[provider]
 }
 
 function baseURLOf(provider: Provider, value: ImageSettings | undefined): string {
-  const stored = provider === 'google' ? value?.googleEndpoint : provider === 'openai' ? value?.openaiBaseURL : provider === 'seedream' ? value?.seedreamBaseURL : value?.dashscopeEndpoint
+  const stored = provider === 'google' ? value?.googleEndpoint : provider === 'openai' ? value?.openaiBaseURL : provider === 'seedream' ? value?.seedreamBaseURL : provider === 'dashscope' ? value?.dashscopeEndpoint : value?.comfyuiBaseURL
   return typeof stored === 'string' && stored.length > 0 ? stored : DEFAULT_BASE_URLS[provider]
 }
 

--- a/src/comfyui-workflow.ts
+++ b/src/comfyui-workflow.ts
@@ -1,0 +1,91 @@
+/** Pure ComfyUI API-workflow validation and placeholder injection. */
+import { MAX_COMFYUI_WORKFLOW_BYTES } from './shared.js'
+
+export const COMFYUI_PROMPT_PLACEHOLDER = '{{prompt}}'
+export const COMFYUI_SEED_PLACEHOLDER = '{{seed}}'
+
+type JsonRecord = Record<string, unknown>
+
+/** Validate imported JSON without exposing workflow graph details to callers. */
+export function validateComfyUIWorkflowJson(workflowJson: string): void {
+  parseWorkflow(workflowJson)
+}
+
+/** Parse, clone, and inject one prompt plus an optional randomized seed. */
+export function prepareComfyUIWorkflow(workflowJson: string, prompt: string, seed = randomSeed()): JsonRecord {
+  const workflow = parseWorkflow(workflowJson)
+  let promptReplacements = 0
+
+  const inject = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      if (value === COMFYUI_PROMPT_PLACEHOLDER) {
+        promptReplacements += 1
+        return prompt
+      }
+      if (value === COMFYUI_SEED_PLACEHOLDER) return seed
+      if (value.includes(COMFYUI_PROMPT_PLACEHOLDER)) {
+        promptReplacements += 1
+        return value.replaceAll(COMFYUI_PROMPT_PLACEHOLDER, prompt)
+      }
+      return value.includes(COMFYUI_SEED_PLACEHOLDER)
+        ? value.replaceAll(COMFYUI_SEED_PLACEHOLDER, String(seed))
+        : value
+    }
+    if (Array.isArray(value)) return value.map(inject)
+    if (!isRecord(value)) return value
+    return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, inject(child)]))
+  }
+
+  const prepared = Object.fromEntries(Object.entries(workflow).map(([nodeId, value]) => {
+    const node = record(value)
+    const inputs = node === undefined ? undefined : record(node.inputs)
+    return inputs === undefined
+      ? [nodeId, value]
+      : [nodeId, { ...node, inputs: inject(inputs) }]
+  }))
+  if (promptReplacements === 0) {
+    throw new Error(`ComfyUI workflow must contain ${COMFYUI_PROMPT_PLACEHOLDER} in a text input`)
+  }
+  return prepared
+}
+
+function parseWorkflow(workflowJson: string): JsonRecord {
+  if (workflowJson.trim().length === 0) throw new Error('Import a ComfyUI API workflow JSON file in Settings before generating')
+  if (new TextEncoder().encode(workflowJson).byteLength > MAX_COMFYUI_WORKFLOW_BYTES) {
+    throw new Error('ComfyUI workflow file must be no larger than 5 MB')
+  }
+  let value: unknown
+  try {
+    value = JSON.parse(workflowJson)
+  } catch {
+    throw new Error('ComfyUI workflow file is not valid JSON')
+  }
+  if (!isRecord(value) || Object.keys(value).length === 0) {
+    throw new Error('ComfyUI workflow must be a non-empty API-format JSON object')
+  }
+  if (!Object.values(value).some(node => {
+    const inputs = record(node)?.inputs
+    return inputs !== undefined && containsPromptPlaceholder(inputs)
+  })) {
+    throw new Error(`ComfyUI workflow must contain ${COMFYUI_PROMPT_PLACEHOLDER} in a text input`)
+  }
+  return value
+}
+
+function containsPromptPlaceholder(value: unknown): boolean {
+  if (typeof value === 'string') return value.includes(COMFYUI_PROMPT_PLACEHOLDER)
+  if (Array.isArray(value)) return value.some(containsPromptPlaceholder)
+  return isRecord(value) && Object.values(value).some(containsPromptPlaceholder)
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function record(value: unknown): JsonRecord | undefined {
+  return isRecord(value) ? value : undefined
+}
+
+function randomSeed(): number {
+  return Math.floor(Math.random() * 0x1_0000_0000)
+}

--- a/src/comfyui.ts
+++ b/src/comfyui.ts
@@ -1,0 +1,192 @@
+/** ComfyUI text-to-image adapter using an imported API-format workflow. */
+import type { ImageMediaType } from '@deepseek-ai/dsh-attachment'
+import { prepareComfyUIWorkflow } from './comfyui-workflow.js'
+
+const ERROR_LIMIT = 4096
+const POLL_INTERVAL_MS = 500
+const MAX_HISTORY_BYTES = 16 * 1024 * 1024
+
+export interface GeneratedComfyUIImage {
+  data: Uint8Array
+  mediaType: ImageMediaType
+}
+
+/** Run one ComfyUI workflow and return its first final image. */
+export async function generateComfyUIImage(input: {
+  baseURL: string
+  workflowJson: string
+  prompt: string
+  timeoutMs: number
+  maxBytes: number
+  signal: AbortSignal
+}): Promise<GeneratedComfyUIImage> {
+  input.signal.throwIfAborted()
+  const baseURL = comfyUIBaseURL(input.baseURL)
+  const workflow = prepareComfyUIWorkflow(input.workflowJson, input.prompt)
+  const controller = new AbortController()
+  const forwardAbort = (): void => { controller.abort(input.signal.reason) }
+  input.signal.addEventListener('abort', forwardAbort, { once: true })
+  const timeout = setTimeout(() => { controller.abort(new Error('ComfyUI generation timed out')) }, input.timeoutMs)
+
+  try {
+    const promptId = await submitWorkflow(baseURL, workflow, controller.signal)
+    const output = await waitForOutput(baseURL, promptId, controller.signal)
+    return await downloadOutput(baseURL, output, input.maxBytes, controller.signal)
+  } catch (error) {
+    input.signal.throwIfAborted()
+    if (controller.signal.aborted) throw new Error(`ComfyUI generation timed out after ${String(input.timeoutMs)} ms`)
+    if (error instanceof TypeError) throw new Error(`Could not connect to ComfyUI at ${baseURL.origin}`)
+    throw error
+  } finally {
+    clearTimeout(timeout)
+    input.signal.removeEventListener('abort', forwardAbort)
+  }
+}
+
+async function submitWorkflow(baseURL: URL, workflow: Record<string, unknown>, signal: AbortSignal): Promise<string> {
+  const response = await fetch(endpoint(baseURL, 'prompt'), {
+    method: 'POST', redirect: 'error', signal,
+    headers: { 'content-type': 'application/json', accept: 'application/json' },
+    body: JSON.stringify({ prompt: workflow }),
+  })
+  const text = await readBoundedText(response, ERROR_LIMIT)
+  if (!response.ok) throw new Error(`ComfyUI rejected the workflow (${response.status}): ${text}`)
+  const payload = parseJsonRecord(text, 'ComfyUI /prompt returned invalid JSON')
+  if (typeof payload.prompt_id !== 'string' || payload.prompt_id.length === 0) {
+    throw new Error(`ComfyUI /prompt returned no prompt_id: ${text}`)
+  }
+  return payload.prompt_id
+}
+
+async function waitForOutput(baseURL: URL, promptId: string, signal: AbortSignal): Promise<ComfyUIImageOutput> {
+  for (;;) {
+    signal.throwIfAborted()
+    const response = await fetch(endpoint(baseURL, `history/${encodeURIComponent(promptId)}`), {
+      redirect: 'error', signal, headers: { accept: 'application/json' },
+    })
+    const text = await readBoundedText(response, MAX_HISTORY_BYTES)
+    if (!response.ok) throw new Error(`ComfyUI history request failed (${response.status}): ${text.slice(0, ERROR_LIMIT)}`)
+    const history = parseJsonRecord(text, 'ComfyUI history returned invalid JSON')
+    const entry = record(history[promptId])
+    if (entry !== undefined) {
+      const status = record(entry.status)
+      if (status?.status_str === 'error') {
+        throw new Error(`ComfyUI workflow failed: ${JSON.stringify(status.messages ?? status).slice(0, ERROR_LIMIT)}`)
+      }
+      const output = firstOutputImage(entry.outputs)
+      if (output !== undefined) return output
+      if (status?.completed === true) throw new Error('ComfyUI workflow completed without an output image')
+    }
+    await delay(POLL_INTERVAL_MS, signal)
+  }
+}
+
+interface ComfyUIImageOutput {
+  filename: string
+  subfolder: string
+  type: string
+}
+
+function firstOutputImage(value: unknown): ComfyUIImageOutput | undefined {
+  const outputs = record(value)
+  if (outputs === undefined) return undefined
+  for (const nodeOutput of Object.values(outputs)) {
+    const images = record(nodeOutput)?.images
+    if (!Array.isArray(images)) continue
+    for (const image of images) {
+      const item = record(image)
+      if (typeof item?.filename !== 'string' || item.filename.length === 0) continue
+      const output = {
+        filename: item.filename,
+        subfolder: typeof item.subfolder === 'string' ? item.subfolder : '',
+        type: typeof item.type === 'string' ? item.type : 'output',
+      }
+      if (output.type === 'output') return output
+    }
+  }
+  return undefined
+}
+
+async function downloadOutput(baseURL: URL, output: ComfyUIImageOutput, maxBytes: number, signal: AbortSignal): Promise<GeneratedComfyUIImage> {
+  const url = endpoint(baseURL, 'view')
+  url.searchParams.set('filename', output.filename)
+  url.searchParams.set('subfolder', output.subfolder)
+  url.searchParams.set('type', output.type)
+  const response = await fetch(url, { redirect: 'error', signal })
+  if (!response.ok) throw new Error(`ComfyUI image download failed (${response.status})`)
+  const mediaType = imageMediaType(response.headers.get('content-type')) ?? imageMediaTypeFromName(output.filename)
+  if (mediaType === undefined) throw new Error('ComfyUI image download returned an unsupported content type')
+  return { data: await readBoundedBytes(response, maxBytes), mediaType }
+}
+
+function comfyUIBaseURL(value: string): URL {
+  let url: URL
+  try { url = new URL(value.endsWith('/') ? value : `${value}/`) } catch { throw new Error('ComfyUI URL must be an absolute http:// or https:// URL') }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('ComfyUI URL must use http:// or https://')
+  return url
+}
+
+function endpoint(baseURL: URL, path: string): URL {
+  return new URL(path, baseURL)
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+function parseJsonRecord(text: string, message: string): Record<string, unknown> {
+  let value: unknown
+  try { value = JSON.parse(text) } catch { throw new Error(message) }
+  const parsed = record(value)
+  if (parsed === undefined) throw new Error(message)
+  return parsed
+}
+
+function imageMediaType(value: string | null | undefined): ImageMediaType | undefined {
+  const mediaType = value?.split(';', 1)[0]?.trim().toLowerCase()
+  return mediaType === 'image/png' || mediaType === 'image/jpeg' || mediaType === 'image/webp' || mediaType === 'image/gif' ? mediaType : undefined
+}
+
+function imageMediaTypeFromName(filename: string): ImageMediaType | undefined {
+  const lower = filename.toLowerCase()
+  if (lower.endsWith('.png')) return 'image/png'
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg'
+  if (lower.endsWith('.webp')) return 'image/webp'
+  if (lower.endsWith('.gif')) return 'image/gif'
+  return undefined
+}
+
+async function delay(milliseconds: number, signal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(done, milliseconds)
+    const abort = (): void => { clearTimeout(timer); signal.removeEventListener('abort', abort); reject(signal.reason) }
+    function done(): void { signal.removeEventListener('abort', abort); resolve() }
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
+
+async function readBoundedText(response: Response, maxBytes: number): Promise<string> {
+  return new TextDecoder().decode(await readBoundedBytes(response, maxBytes))
+}
+
+async function readBoundedBytes(response: Response, maxBytes: number): Promise<Uint8Array> {
+  if (response.body === null) return new Uint8Array()
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let bytes = 0
+  try {
+    for (;;) {
+      const next = await reader.read()
+      if (next.done) break
+      bytes += next.value.byteLength
+      if (bytes > maxBytes) throw new Error(`ComfyUI response exceeded the ${String(maxBytes)} byte limit`)
+      chunks.push(next.value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  const joined = new Uint8Array(bytes)
+  let offset = 0
+  for (const chunk of chunks) { joined.set(chunk, offset); offset += chunk.byteLength }
+  return joined
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,9 @@ import z from '@deepseek-ai/schemastery'
 import {
   DEFAULT_DASHSCOPE_ENDPOINT,
   DEFAULT_DASHSCOPE_MODEL,
+  DEFAULT_COMFYUI_BASE_URL,
+  DEFAULT_COMFYUI_TIMEOUT_MS,
+  DEFAULT_COMFYUI_WORKFLOW_LABEL,
   DEFAULT_GOOGLE_ENDPOINT,
   DEFAULT_GOOGLE_MODEL,
   DEFAULT_OPENAI_BASE_URL,
@@ -17,6 +20,9 @@ import {
 export {
   DEFAULT_DASHSCOPE_ENDPOINT,
   DEFAULT_DASHSCOPE_MODEL,
+  DEFAULT_COMFYUI_BASE_URL,
+  DEFAULT_COMFYUI_TIMEOUT_MS,
+  DEFAULT_COMFYUI_WORKFLOW_LABEL,
   DEFAULT_GOOGLE_ENDPOINT,
   DEFAULT_GOOGLE_MODEL,
   DEFAULT_OPENAI_BASE_URL,
@@ -56,6 +62,12 @@ export interface Config {
   seedreamModel?: string
   dashscopeEndpoint?: string
   dashscopeModel?: string
+  comfyuiBaseURL?: string
+  /** ComfyUI API-format workflow JSON imported through the Web settings page. */
+  comfyuiWorkflowJson?: string
+  /** Original imported file name, used as a human-readable result label. */
+  comfyuiWorkflowName?: string
+  comfyuiTimeoutMs?: number
   /** Also write every generated image as a file under the session workspace. */
   saveToWorkspace?: boolean
   /** Workspace subfolder for generated images; empty means the workspace root. */
@@ -73,6 +85,10 @@ export const Config: z<Config> = z.object({
   seedreamModel: z.string().default(DEFAULT_SEEDREAM_MODEL),
   dashscopeEndpoint: z.string().default(DEFAULT_DASHSCOPE_ENDPOINT),
   dashscopeModel: z.string().default(DEFAULT_DASHSCOPE_MODEL),
+  comfyuiBaseURL: z.string().default(DEFAULT_COMFYUI_BASE_URL),
+  comfyuiWorkflowJson: z.string().default(''),
+  comfyuiWorkflowName: z.string().default(''),
+  comfyuiTimeoutMs: z.number().min(1_000).max(3_600_000).default(DEFAULT_COMFYUI_TIMEOUT_MS),
   saveToWorkspace: z.boolean().default(true),
   workspaceFolder: z.string().default(DEFAULT_WORKSPACE_FOLDER),
 })
@@ -82,11 +98,19 @@ export function resolveProvider(config: Config):
   | { provider: 'google'; apiKeyEnv: string; model: string; endpoint: string; aspectRatio: AspectRatio; imageSize: ImageSize }
   | { provider: 'openai'; apiKeyEnv: string; model: string; baseURL: string; imageSize: string }
   | { provider: 'seedream'; apiKeyEnv: string; model: string; baseURL: string; imageSize: string }
-  | { provider: 'dashscope'; apiKeyEnv: string; model: string; endpoint: string; imageSize: string } {
+  | { provider: 'dashscope'; apiKeyEnv: string; model: string; endpoint: string; imageSize: string }
+  | { provider: 'comfyui'; baseURL: string; workflowJson: string; workflowName: string; timeoutMs: number } {
   switch (config.provider ?? 'google') {
     case 'openai': return { provider: 'openai', apiKeyEnv: OPENAI_API_KEY_ENV, model: config.openaiModel ?? DEFAULT_OPENAI_MODEL, baseURL: config.openaiBaseURL ?? DEFAULT_OPENAI_BASE_URL, imageSize: '1024x1024' }
     case 'seedream': return { provider: 'seedream', apiKeyEnv: SEEDREAM_API_KEY_ENV, model: config.seedreamModel ?? DEFAULT_SEEDREAM_MODEL, baseURL: config.seedreamBaseURL ?? DEFAULT_SEEDREAM_BASE_URL, imageSize: '2K' }
     case 'dashscope': return { provider: 'dashscope', apiKeyEnv: DASHSCOPE_API_KEY_ENV, model: config.dashscopeModel ?? DEFAULT_DASHSCOPE_MODEL, endpoint: config.dashscopeEndpoint ?? DEFAULT_DASHSCOPE_ENDPOINT, imageSize: '1024*1024' }
+    case 'comfyui': return {
+      provider: 'comfyui',
+      baseURL: config.comfyuiBaseURL ?? DEFAULT_COMFYUI_BASE_URL,
+      workflowJson: config.comfyuiWorkflowJson ?? '',
+      workflowName: config.comfyuiWorkflowName?.trim() || DEFAULT_COMFYUI_WORKFLOW_LABEL,
+      timeoutMs: config.comfyuiTimeoutMs ?? DEFAULT_COMFYUI_TIMEOUT_MS,
+    }
     case 'google': return { provider: 'google', apiKeyEnv: GOOGLE_API_KEY_ENV, model: config.googleModel ?? DEFAULT_GOOGLE_MODEL, endpoint: config.googleEndpoint ?? DEFAULT_GOOGLE_ENDPOINT, aspectRatio: '1:1', imageSize: '1K' }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import type {} from '@deepseek-ai/dsh-host-webserver'
 import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import { defineTool, type ToolResult } from '@deepseek-ai/dsh-tools'
 import { Config, resolveProvider, type AspectRatio, type ImageProvider, type ImageSize } from './config.js'
+import { generateComfyUIImage } from './comfyui.js'
 import { editDashScopeImage, generateDashScopeImage } from './dashscope.js'
 import { editGoogleImage, generateGoogleImage } from './google.js'
 import { IMAGE_ROUTE, imageAttachmentFromMeta, serveImage } from './image-route.js'
@@ -52,6 +53,17 @@ export function apply(ctx: Context, config: Config = {}): void {
     output: imageOutput('Generated'),
     async execute(args, exec): Promise<GeneratedValue> {
       const active = resolveProvider(current())
+      if (active.provider === 'comfyui') {
+        const generated = await generateComfyUIImage({
+          baseURL: active.baseURL,
+          workflowJson: active.workflowJson,
+          prompt: args.prompt,
+          timeoutMs: active.timeoutMs,
+          maxBytes: ctx.attachments.imageLimits.maxImageBytes,
+          signal: exec.signal,
+        })
+        return saveGenerated(ctx, generated, active.provider, active.workflowName, 'API workflow', current(), exec)
+      }
       const credential = await ctx.credentials.resolve(credentialRef(active.apiKeyEnv))
       if (credential === undefined || credential.value.length === 0) throw new Error(`generate_image requires the ${active.apiKeyEnv} credential; configure it in Settings > Plugins > Image generation.`)
       if (active.provider === 'google') {
@@ -88,6 +100,9 @@ export function apply(ctx: Context, config: Config = {}): void {
     output: imageOutput('Edited'),
     async execute(args, exec): Promise<GeneratedValue> {
       const active = resolveProvider(current())
+      if (active.provider === 'comfyui') {
+        throw new Error('edit_image is not yet supported by the ComfyUI provider; switch providers or use generate_image')
+      }
       const credential = await ctx.credentials.resolve(credentialRef(active.apiKeyEnv))
       if (credential === undefined || credential.value.length === 0) throw new Error(`edit_image requires the ${active.apiKeyEnv} credential; configure it in Settings > Plugins > Image generation.`)
       const sourceImages = await resolveReferenceImages({

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,7 +6,7 @@ export const IMAGE_ROUTE = '/plugins/dsh-image-gen/image'
 export const IMAGE_GENERATION_NAMESPACE = 'image-generation'
 
 /** Supported providers. */
-export const IMAGE_PROVIDERS = ['google', 'openai', 'seedream', 'dashscope'] as const
+export const IMAGE_PROVIDERS = ['google', 'openai', 'seedream', 'dashscope', 'comfyui'] as const
 export type ImageProvider = typeof IMAGE_PROVIDERS[number]
 
 /** Default endpoints and base URLs. */
@@ -14,6 +14,10 @@ export const DEFAULT_GOOGLE_ENDPOINT = 'https://generativelanguage.googleapis.co
 export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
 export const DEFAULT_SEEDREAM_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3'
 export const DEFAULT_DASHSCOPE_ENDPOINT = 'https://dashscope.aliyuncs.com/api/v1'
+export const DEFAULT_COMFYUI_BASE_URL = 'http://127.0.0.1:8188'
+export const DEFAULT_COMFYUI_TIMEOUT_MS = 300_000
+export const DEFAULT_COMFYUI_WORKFLOW_LABEL = 'API workflow'
+export const MAX_COMFYUI_WORKFLOW_BYTES = 5 * 1024 * 1024
 
 /** Default model names. */
 export const DEFAULT_GOOGLE_MODEL = 'gemini-3.1-flash-image'
@@ -26,6 +30,7 @@ export const DEFAULT_MODELS: Record<ImageProvider, string> = {
   openai: DEFAULT_OPENAI_MODEL,
   seedream: DEFAULT_SEEDREAM_MODEL,
   dashscope: DEFAULT_DASHSCOPE_MODEL,
+  comfyui: DEFAULT_COMFYUI_WORKFLOW_LABEL,
 }
 
 export const DEFAULT_BASE_URLS: Record<ImageProvider, string> = {
@@ -33,4 +38,5 @@ export const DEFAULT_BASE_URLS: Record<ImageProvider, string> = {
   openai: DEFAULT_OPENAI_BASE_URL,
   seedream: DEFAULT_SEEDREAM_BASE_URL,
   dashscope: DEFAULT_DASHSCOPE_ENDPOINT,
+  comfyui: DEFAULT_COMFYUI_BASE_URL,
 }

--- a/tests/client-compat.spec.ts
+++ b/tests/client-compat.spec.ts
@@ -1,0 +1,37 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { describe, expect, it, vi } from 'vitest'
+
+import { apply } from '../src/client/index.js'
+
+describe('latest DSH client compatibility', () => {
+  it('registers the settings card with credentials supplied by the Remote service', () => {
+    const credentials = { describe: vi.fn(), set: vi.fn() }
+    const registrations = new Map<string, () => unknown>()
+    let injectedCredentials: unknown
+    const register = vi.fn((options: { name?: string; inject?: () => { credentials?: unknown } }) => {
+      if (options.name === 'settings.plugin.item') injectedCredentials = options.inject?.().credentials
+      return vi.fn()
+    })
+    const ctx = {
+      remote: { credentials },
+      get: vi.fn((name: string) => name === 'connection' ? {} : undefined),
+      settingsScope: { bind: vi.fn(() => ({ getSnapshot: vi.fn(), subscribe: vi.fn(), set: vi.fn() })) },
+      effect: vi.fn(),
+      slots: {
+        register,
+        inject: vi.fn((name: string, factory: () => unknown) => { registrations.set(name, factory) }),
+      },
+    } as unknown as Context
+
+    apply(ctx)
+
+    const injectSettingsCard = registrations.get('settings.plugin.item')
+    expect(injectSettingsCard).toBeTypeOf('function')
+    expect(() => injectSettingsCard?.()).not.toThrow()
+    expect(register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'settings.plugin.item', key: 'image-generation' }),
+      expect.any(Function),
+    )
+    expect(injectedCredentials).toBe(credentials)
+  })
+})

--- a/tests/comfyui.spec.ts
+++ b/tests/comfyui.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { generateComfyUIImage } from '../src/comfyui.js'
+import { prepareComfyUIWorkflow, validateComfyUIWorkflowJson } from '../src/comfyui-workflow.js'
+
+const WORKFLOW = JSON.stringify({
+  6: {
+    class_type: 'CLIPTextEncode',
+    inputs: { text: '{{prompt}}', seed: '{{seed}}' },
+  },
+})
+
+function options(overrides: Partial<Parameters<typeof generateComfyUIImage>[0]> = {}): Parameters<typeof generateComfyUIImage>[0] {
+  return {
+    baseURL: 'http://127.0.0.1:8188',
+    workflowJson: WORKFLOW,
+    prompt: 'rainy neon street',
+    timeoutMs: 5_000,
+    maxBytes: 1024,
+    signal: new AbortController().signal,
+    ...overrides,
+  }
+}
+
+describe('ComfyUI workflow preparation', () => {
+  it('injects prompt text and a numeric seed without mutating the imported JSON', () => {
+    const prepared = prepareComfyUIWorkflow(WORKFLOW, 'a red panda', 42)
+    expect(prepared).toEqual({
+      6: {
+        class_type: 'CLIPTextEncode',
+        inputs: { text: 'a red panda', seed: 42 },
+      },
+    })
+    expect(WORKFLOW).toContain('{{prompt}}')
+  })
+
+  it('rejects UI or API workflows that do not expose the prompt placeholder', () => {
+    expect(() => validateComfyUIWorkflowJson(JSON.stringify({ 1: { inputs: { text: 'fixed' } } })))
+      .toThrow('must contain {{prompt}}')
+    expect(() => validateComfyUIWorkflowJson(JSON.stringify({ nodes: [{ widgets_values: ['{{prompt}}'] }] })))
+      .toThrow('must contain {{prompt}}')
+  })
+})
+
+describe('ComfyUI image generation', () => {
+  beforeEach(() => { vi.restoreAllMocks() })
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals() })
+
+  it('submits, polls, downloads, and returns the first final output image', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ prompt_id: 'job-1' }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        'job-1': {
+          status: { status_str: 'success', completed: true },
+          outputs: {
+            preview: { images: [{ filename: 'preview.png', subfolder: '', type: 'temp' }] },
+            save: { images: [{ filename: 'final.png', subfolder: 'images', type: 'output' }] },
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { 'content-type': 'image/png' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await generateComfyUIImage(options())
+
+    expect(result).toEqual({ data: new Uint8Array([1, 2, 3]), mediaType: 'image/png' })
+    const submitted = JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body)) as { prompt: { 6: { inputs: { text: string } } } }
+    expect(submitted.prompt[6].inputs.text).toBe('rainy neon street')
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe('http://127.0.0.1:8188/history/job-1')
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('/view?filename=final.png&subfolder=images&type=output')
+  })
+
+  it('reports workflow validation errors returned by ComfyUI', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'bad node' }), { status: 400 })))
+    await expect(generateComfyUIImage(options())).rejects.toThrow('ComfyUI rejected the workflow (400)')
+  })
+
+  it('reports when the configured ComfyUI server cannot be reached', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+    await expect(generateComfyUIImage(options())).rejects.toThrow('Could not connect to ComfyUI at http://127.0.0.1:8188')
+  })
+
+  it('surfaces a failed ComfyUI job instead of waiting until timeout', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ prompt_id: 'job-failed' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        'job-failed': { status: { status_str: 'error', completed: true, messages: ['node execution failed'] } },
+      }), { status: 200 })))
+    await expect(generateComfyUIImage(options())).rejects.toThrow('ComfyUI workflow failed')
+  })
+
+  it('reports a completed job that has no image output', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ prompt_id: 'job-empty' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        'job-empty': { status: { status_str: 'success', completed: true }, outputs: {} },
+      }), { status: 200 })))
+    await expect(generateComfyUIImage(options())).rejects.toThrow('completed without an output image')
+  })
+
+  it('honours cancellation before making a request', async () => {
+    const controller = new AbortController()
+    controller.abort(new Error('cancelled'))
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(generateComfyUIImage(options({ signal: controller.signal }))).rejects.toThrow('cancelled')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('enforces one timeout across submission, polling, and download', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ prompt_id: 'job-slow' }), { status: 200 }))
+      .mockImplementation(async () => new Response('{}', { status: 200 })))
+
+    const pending = generateComfyUIImage(options({ timeoutMs: 1_000 }))
+    const assertion = expect(pending).rejects.toThrow('timed out after 1000 ms')
+    await vi.advanceTimersByTimeAsync(1_001)
+    await assertion
+  })
+})

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -3,6 +3,9 @@ import {
   Config,
   DEFAULT_DASHSCOPE_ENDPOINT,
   DEFAULT_DASHSCOPE_MODEL,
+  DEFAULT_COMFYUI_BASE_URL,
+  DEFAULT_COMFYUI_TIMEOUT_MS,
+  DEFAULT_COMFYUI_WORKFLOW_LABEL,
   DEFAULT_GOOGLE_ENDPOINT,
   DEFAULT_GOOGLE_MODEL,
   DEFAULT_OPENAI_BASE_URL,
@@ -31,6 +34,16 @@ describe('resolveProvider', () => {
       imageSize: '1024*1024',
     })
   })
+
+  it('resolves a credential-free ComfyUI profile', () => {
+    expect(resolveProvider({ provider: 'comfyui' })).toEqual({
+      provider: 'comfyui',
+      baseURL: DEFAULT_COMFYUI_BASE_URL,
+      workflowJson: '',
+      workflowName: DEFAULT_COMFYUI_WORKFLOW_LABEL,
+      timeoutMs: DEFAULT_COMFYUI_TIMEOUT_MS,
+    })
+  })
 })
 
 describe('Config Schema validation', () => {
@@ -39,6 +52,13 @@ describe('Config Schema validation', () => {
     expect(validated.provider).toBe('dashscope')
     expect(validated.dashscopeModel).toBe(DEFAULT_DASHSCOPE_MODEL)
     expect(validated.dashscopeEndpoint).toBe(DEFAULT_DASHSCOPE_ENDPOINT)
+  })
+
+  it('validates provider: comfyui and applies local defaults', () => {
+    const validated = Config({ provider: 'comfyui' })
+    expect(validated.provider).toBe('comfyui')
+    expect(validated.comfyuiBaseURL).toBe(DEFAULT_COMFYUI_BASE_URL)
+    expect(validated.comfyuiTimeoutMs).toBe(DEFAULT_COMFYUI_TIMEOUT_MS)
   })
 })
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,7 +1,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import type { ImageAttachmentRef } from '@deepseek-ai/dsh-attachment'
 import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@deepseek-ai/dsh-settings', () => ({
   settingsNamespace: (value: string) => value,
@@ -34,7 +34,7 @@ function harnessContext(): { ctx: Context; tools: ToolDefinition[] } {
         mediaTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/gif'],
       },
       readImage: vi.fn(),
-      saveImage: vi.fn(),
+      saveImage: vi.fn(async () => attachment('sha256:saved-image')),
     },
     logger: { warn: vi.fn() },
   } as unknown as Context
@@ -49,6 +49,7 @@ function toolByName(tools: ToolDefinition[], name: string): ToolDefinition {
 
 describe('image tool registration', () => {
   beforeEach(() => { vi.clearAllMocks() })
+  afterEach(() => { vi.unstubAllGlobals() })
 
   it('registers generate_image and edit_image', () => {
     const { ctx, tools } = harnessContext()
@@ -91,5 +92,43 @@ describe('image tool registration', () => {
 
     expect(edit.description).toContain('NEVER call read_image, glob, or shell')
     expect(edit.description).toContain('call edit_image immediately with prompt only')
+  })
+
+  it('routes ComfyUI generation without resolving an API credential', async () => {
+    const { ctx, tools } = harnessContext()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ prompt_id: 'job-1' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        'job-1': {
+          status: { status_str: 'success', completed: true },
+          outputs: { save: { images: [{ filename: 'final.png', subfolder: '', type: 'output' }] } },
+        },
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { 'content-type': 'image/png' } })))
+    apply(ctx, {
+      provider: 'comfyui',
+      comfyuiWorkflowJson: JSON.stringify({ 6: { class_type: 'CLIPTextEncode', inputs: { text: '{{prompt}}' } } }),
+      comfyuiWorkflowName: 'portrait.json',
+      saveToWorkspace: false,
+    })
+
+    const value = await toolByName(tools, 'generate_image').execute(
+      { prompt: 'a portrait' },
+      { signal: new AbortController().signal } as never,
+    ) as { provider: string; model: string; attachment: ImageAttachmentRef }
+
+    expect(value).toMatchObject({ provider: 'comfyui', model: 'portrait.json', attachment: attachment('sha256:saved-image') })
+    expect(ctx.credentials.resolve).not.toHaveBeenCalled()
+  })
+
+  it('fails clearly before image lookup when ComfyUI editing is requested', async () => {
+    const { ctx, tools } = harnessContext()
+    apply(ctx, { provider: 'comfyui', saveToWorkspace: false })
+
+    await expect(toolByName(tools, 'edit_image').execute(
+      { prompt: 'restyle it' },
+      { signal: new AbortController().signal } as never,
+    )).rejects.toThrow('edit_image is not yet supported by the ComfyUI provider')
+    expect(ctx.credentials.resolve).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #10. Adds a local ComfyUI text-to-image Provider using imported API Format workflows, prompt and seed injection, task polling, output download, settings UI, documentation, and tests. ComfyUI edit_image remains unsupported in this MVP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local ComfyUI as an image-generation provider.
  * Added ComfyUI workflow import with `{{prompt}}` and optional `{{seed}}` placeholders.
  * Added configurable ComfyUI URL, workflow name, and timeout settings.
  * Added text-to-image generation, progress handling, and gallery saving for ComfyUI results.
* **Documentation**
  * Updated setup guides and provider references in English and Chinese.
  * Added ComfyUI configuration instructions and supported-provider details.
* **Limitations**
  * ComfyUI currently supports text-to-image generation only; image editing is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->