### PR TITLE
fix(openai-compatible): detect image media type from bytes

### DIFF
--- a/src/openai-compatible.ts
+++ b/src/openai-compatible.ts
@@ -1,6 +1,7 @@
 /** OpenAI Images API and compatible response adapter. */
 import type { ImageMediaType } from '@deepseek-ai/dsh-attachment'
 import { redactSecrets } from './redact.js'
+import { detectImageMediaType } from './reference-image.js'
 
 const ERROR_LIMIT = 4096
 
@@ -113,9 +114,10 @@ async function downloadImage(
     ...(input.apiKey === undefined ? {} : { headers: { authorization: `Bearer ${input.apiKey}` } }),
   })
   if (!response.ok) throw new Error(`${provider} image download failed (${response.status})`)
-  const mediaType = imageMediaType(response.headers.get('content-type'))
+  const data = await readBoundedBytes(response, input.maxBytes)
+  const mediaType = detectImageMediaType(data) ?? imageMediaType(response.headers.get('content-type'))
   if (mediaType === undefined) throw new Error(`${provider} image download returned unsupported content type`)
-  return { data: await readBoundedBytes(response, input.maxBytes), mediaType }
+  return { data, mediaType }
 }
 
 function parseDataUrl(value: string): { mediaType: string; base64: string } | undefined {

--- a/src/reference-image.ts
+++ b/src/reference-image.ts
@@ -299,7 +299,7 @@ function mergeSelectors(input: {
   return input.multiple
 }
 
-function detectImageMediaType(data: Uint8Array): ImageMediaType | undefined {
+export function detectImageMediaType(data: Uint8Array): ImageMediaType | undefined {
   if (startsWith(data, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return 'image/png'
   if (startsWith(data, [0xff, 0xd8, 0xff])) return 'image/jpeg'
   if (ascii(data, 0, 6) === 'GIF87a' || ascii(data, 0, 6) === 'GIF89a') return 'image/gif'


### PR DESCRIPTION
## Problem

`generateOpenAICompatibleImage` (used by the zhipu/glm-image provider, plus
openai/xai/openai-compat) sets the image `mediaType` from the `Content-Type`
response header only. Zhipu's image CDN serves JPEG bytes with a
`Content-Type: image/png` header, so the DSH attachment store rejects it with
`IMAGE_TYPE_MISMATCH` ("Declared image type does not match its bytes").

## Fix

Detect the media type from image bytes (magic numbers) first, falling back to
the `Content-Type` header. Reuses the existing `detectImageMediaType()` helper
(now exported from `reference-image.ts`).

- `src/reference-image.ts`: export `detectImageMediaType`
- `src/openai-compatible.ts`: import it and use byte detection in `downloadImage`

No change to other providers (seedream/dashscope/google/comfyui).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling by detecting the actual image format from downloaded data.
  * Image downloads now work more reliably when server-provided content types are missing or incorrect.
  * Unsupported images are rejected only when neither the detected format nor the provided content type is supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->